### PR TITLE
feat: agent vs agent matchup heatmap (#10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,6 +191,7 @@ cython_debug/
 # openspiel-arena runtime outputs
 results/
 !results/.gitkeep
+output/
 
 # Ruff stuff:
 .ruff_cache/

--- a/analysis/matchup_heatmap.ipynb
+++ b/analysis/matchup_heatmap.ipynb
@@ -1,0 +1,375 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Agent vs Agent Matchup Heatmap\n",
+    "\n",
+    "This notebook demonstrates how to visualize pairwise win rates between agents using a heatmap.\n",
+    "\n",
+    "## What the Heatmap Shows\n",
+    "\n",
+    "The heatmap displays the **win rate** of each agent (row) against each opponent (column):\n",
+    "\n",
+    "- **Cell value**: Win rate of the row agent vs the column agent (0% to 100%)\n",
+    "- **Diagonal**: Grayed out (no self-play data)\n",
+    "- **Color scale**: Diverging colormap centered at 50% (green = row agent wins more, red = column agent wins more)\n",
+    "\n",
+    "### Interpreting the Heatmap\n",
+    "\n",
+    "- **Green cells**: The row agent beats the column agent more often than not\n",
+    "- **Red cells**: The column agent beats the row agent more often than not\n",
+    "- **Yellow cells**: Roughly even matchup (~50% win rate)\n",
+    "\n",
+    "### Side-Balanced Aggregation\n",
+    "\n",
+    "In games where the starting position matters (like Breakthrough), we can compute a **side-balanced** win rate that averages across both starting positions. This gives a fairer comparison when agents perform differently depending on which side they play."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Add project root to path\n",
+    "project_root = Path(\"..\").resolve()\n",
+    "if str(project_root) not in sys.path:\n",
+    "    sys.path.insert(0, str(project_root))\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n",
+    "\n",
+    "from scripts.plot_matchup_heatmap import (\n",
+    "    compute_matchup_matrix_from_csv,\n",
+    "    plot_heatmap,\n",
+    "    save_matrix_csv,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load Results\n",
+    "\n",
+    "We'll load match results from CSV files in the `results/` directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Find all CSV result files\n",
+    "results_dir = project_root / \"results\"\n",
+    "csv_files = sorted(results_dir.glob(\"*.csv\"))\n",
+    "\n",
+    "print(f\"Found {len(csv_files)} CSV files in {results_dir}\")\n",
+    "if csv_files:\n",
+    "    print(f\"Example files: {[f.name for f in csv_files[:3]]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compute the Matchup Matrix\n",
+    "\n",
+    "The matchup matrix contains win rates for every pair of agents."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compute matchup matrix from all CSV files\n",
+    "csv_paths = [str(f) for f in csv_files]\n",
+    "matrix = compute_matchup_matrix_from_csv(*csv_paths)\n",
+    "\n",
+    "print(f\"Game: {matrix.game or 'Multiple games'}\")\n",
+    "print(f\"Agents found ({len(matrix.agents)}): {', '.join(sorted(matrix.agents))}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Filter by Game (Optional)\n",
+    "\n",
+    "If results contain multiple games, we can filter to a specific one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check what games are in the data\n",
+    "import csv\n",
+    "\n",
+    "games_found = set()\n",
+    "for csv_file in csv_files:\n",
+    "    with open(csv_file, newline=\"\", encoding=\"utf-8\") as f:\n",
+    "        reader = csv.DictReader(f)\n",
+    "        for row in reader:\n",
+    "            games_found.add(row.get(\"game\", \"unknown\"))\n",
+    "\n",
+    "print(f\"Games in data: {sorted(games_found)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Filter to a specific game (e.g., breakthrough)\n",
+    "game_filter = \"breakthrough\" if \"breakthrough\" in games_found else None\n",
+    "\n",
+    "if game_filter:\n",
+    "    matrix_filtered = compute_matchup_matrix_from_csv(*csv_paths, game_filter=game_filter)\n",
+    "    print(f\"Filtered to {game_filter}: {len(matrix_filtered.agents)} agents\")\n",
+    "else:\n",
+    "    matrix_filtered = matrix\n",
+    "    print(\"Using all games\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Display the Win Rate Matrix\n",
+    "\n",
+    "Let's look at the raw win rate data as a DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Convert to DataFrame for easy viewing\n",
+    "sorted_agents = sorted(matrix_filtered.agents)\n",
+    "win_rates = matrix_filtered.to_matrix(side_balanced=False)\n",
+    "\n",
+    "df = pd.DataFrame(win_rates, index=sorted_agents, columns=sorted_agents)\n",
+    "df.style.format(\"{:.0%}\").background_gradient(cmap=\"RdYlGn\", axis=None, vmin=0, vmax=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot the Heatmap\n",
+    "\n",
+    "Now let's visualize the matchup data as a heatmap."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create output directory\n",
+    "output_dir = project_root / \"output\"\n",
+    "output_dir.mkdir(exist_ok=True)\n",
+    "\n",
+    "# Plot standard heatmap\n",
+    "output_path = output_dir / \"matchup_heatmap_notebook.png\"\n",
+    "plot_heatmap(\n",
+    "    matrix_filtered,\n",
+    "    output_path=output_path,\n",
+    "    side_balanced=False,\n",
+    "    annotate=True,\n",
+    "    show_samples=True,\n",
+    ")\n",
+    "\n",
+    "# Display the image\n",
+    "from IPython.display import Image\n",
+    "Image(filename=output_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Side-Balanced Heatmap\n",
+    "\n",
+    "For games where starting position matters, the side-balanced heatmap shows fairer comparisons."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot side-balanced heatmap\n",
+    "output_path_balanced = output_dir / \"matchup_heatmap_side_balanced_notebook.png\"\n",
+    "plot_heatmap(\n",
+    "    matrix_filtered,\n",
+    "    output_path=output_path_balanced,\n",
+    "    side_balanced=True,\n",
+    "    annotate=True,\n",
+    "    show_samples=True,\n",
+    ")\n",
+    "\n",
+    "Image(filename=output_path_balanced)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Save the Matrix as CSV\n",
+    "\n",
+    "Export the win rate matrix for further analysis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save to CSV\n",
+    "csv_path = output_dir / \"matchup_matrix_notebook.csv\"\n",
+    "save_matrix_csv(matrix_filtered, csv_path, side_balanced=False)\n",
+    "\n",
+    "# Show the CSV content\n",
+    "print(csv_path.read_text())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sample Size Analysis\n",
+    "\n",
+    "Check how many games were played between each agent pair."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sample count matrix\n",
+    "sample_matrix = matrix_filtered.to_sample_matrix()\n",
+    "sample_df = pd.DataFrame(sample_matrix, index=sorted_agents, columns=sorted_agents)\n",
+    "\n",
+    "print(\"Sample sizes (number of games between each agent pair):\")\n",
+    "sample_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary Statistics\n",
+    "\n",
+    "Compute overall performance metrics for each agent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Calculate average win rate for each agent\n",
+    "summary_data = []\n",
+    "\n",
+    "for agent in sorted_agents:\n",
+    "    # Get win rates against all opponents (excluding self)\n",
+    "    win_rates_vs_others = [\n",
+    "        matrix_filtered.get_win_rate(agent, opponent)\n",
+    "        for opponent in sorted_agents\n",
+    "        if opponent != agent\n",
+    "    ]\n",
+    "    \n",
+    "    # Filter out NaN values\n",
+    "    valid_rates = [r for r in win_rates_vs_others if not np.isnan(r)]\n",
+    "    \n",
+    "    if valid_rates:\n",
+    "        avg_win_rate = np.mean(valid_rates)\n",
+    "        min_win_rate = np.min(valid_rates)\n",
+    "        max_win_rate = np.max(valid_rates)\n",
+    "    else:\n",
+    "        avg_win_rate = min_win_rate = max_win_rate = np.nan\n",
+    "    \n",
+    "    # Total games\n",
+    "    total_games = sum(matrix_filtered.get_sample_count(agent, opp) for opp in sorted_agents) // 2\n",
+    "    \n",
+    "    summary_data.append({\n",
+    "        \"Agent\": agent,\n",
+    "        \"Avg Win Rate\": avg_win_rate,\n",
+    "        \"Min Win Rate\": min_win_rate,\n",
+    "        \"Max Win Rate\": max_win_rate,\n",
+    "        \"Total Games\": total_games,\n",
+    "    })\n",
+    "\n",
+    "summary_df = pd.DataFrame(summary_data)\n",
+    "summary_df.style.format({\n",
+    "    \"Avg Win Rate\": \"{:.1%}\",\n",
+    "    \"Min Win Rate\": \"{:.1%}\",\n",
+    "    \"Max Win Rate\": \"{:.1%}\",\n",
+    "    \"Total Games\": \"{:.0f}\",\n",
+    "}).background_gradient(subset=[\"Avg Win Rate\"], cmap=\"RdYlGn\", vmin=0, vmax=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusions\n",
+    "\n",
+    "The matchup heatmap provides a quick visual summary of agent performance:\n",
+    "\n",
+    "1. **Strong agents** appear as green rows (high win rates against most opponents)\n",
+    "2. **Weak agents** appear as red rows (low win rates against most opponents)\n",
+    "3. **Non-transitive relationships** (e.g., A beats B, B beats C, C beats A) show up as patterns where no single agent dominates\n",
+    "\n",
+    "### Next Steps\n",
+    "\n",
+    "- Use the CLI script for batch processing: `python3 scripts/plot_matchup_heatmap.py results/*.csv`\n",
+    "- Compare with rating systems like Elo or Glicko-2 for overall rankings\n",
+    "- Use AlphaRank analysis for computing rankings in non-transitive games"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/scripts/plot_matchup_heatmap.py
+++ b/scripts/plot_matchup_heatmap.py
@@ -1,0 +1,754 @@
+#!/usr/bin/env python3
+"""
+scripts.plot_matchup_heatmap — Agent vs Agent Win Rate Heatmap
+===============================================================
+Generates a heatmap visualization of pairwise win rates between agents.
+
+Features:
+- Reads results from CSV files (canonical arena format)
+- Computes win rate of row agent vs column agent
+- Supports game filtering and side-balanced aggregation
+- Outputs PNG heatmap and CSV matrix
+- Annotates cells with win rate and optional sample size
+
+CLI Usage:
+    python3 scripts/plot_matchup_heatmap.py results/*.csv
+    python3 scripts/plot_matchup_heatmap.py results/*.csv --output-dir output/
+    python3 scripts/plot_matchup_heatmap.py results/*.csv --game breakthrough
+    python3 scripts/plot_matchup_heatmap.py results/*.csv --no-annotate
+    python3 scripts/plot_matchup_heatmap.py results/*.csv --show-samples
+    python3 scripts/plot_matchup_heatmap.py results/*.csv --side-balanced
+
+References
+----------
+- Omidshafiei, S., et al. (2019). "AlphaRank: Multi-Agent Evaluation by Evolution"
+- https://arxiv.org/abs/1903.01373
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Data structures for matchup matrix
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MatchupRecord:
+    """Win/loss/draw record for one agent against another, with side tracking."""
+
+    wins: int = 0
+    losses: int = 0
+    draws: int = 0
+    # Track by which side the agent played (for side-balanced aggregation)
+    wins_as_side_0: int = 0
+    wins_as_side_1: int = 0
+    losses_as_side_0: int = 0
+    losses_as_side_1: int = 0
+    draws_as_side_0: int = 0
+    draws_as_side_1: int = 0
+
+    @property
+    def games(self) -> int:
+        return self.wins + self.losses + self.draws
+
+    @property
+    def win_rate(self) -> float:
+        """Win rate from the perspective of the row agent (0.0 to 1.0)."""
+        if self.games == 0:
+            return 0.0
+        # Wins count 1, draws count 0.5
+        return (self.wins + 0.5 * self.draws) / self.games
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "wins": self.wins,
+            "losses": self.losses,
+            "draws": self.draws,
+            "games": self.games,
+            "win_rate": round(self.win_rate, 4),
+        }
+
+
+@dataclass
+class MatchupMatrix:
+    """Pairwise matchup matrix for a set of agents.
+
+    The matrix M[i][j] gives the win rate of agent i against agent j.
+    Diagonal entries are NaN (no self-play).
+    """
+
+    agents: list[str] = field(default_factory=list)
+    game: str = ""
+    _records: dict[tuple[str, str], MatchupRecord] = field(default_factory=dict)
+
+    def get_record(self, agent_a: str, agent_b: str) -> MatchupRecord:
+        """Get or create the head-to-head record for agent_a vs agent_b."""
+        key = (agent_a, agent_b)
+        if key not in self._records:
+            self._records[key] = MatchupRecord()
+        return self._records[key]
+
+    def add_result(
+        self,
+        agent_a: str,
+        agent_b: str,
+        outcome: str,
+        agent_a_side: int = 0,
+    ) -> None:
+        """Add a match result.
+
+        Parameters
+        ----------
+        agent_a:
+            Name of the first agent (row agent).
+        agent_b:
+            Name of the second agent (column agent).
+        outcome:
+            "win", "loss", or "draw" from agent_a's perspective.
+        agent_a_side:
+            Which side agent_a played (0 or 1).
+        """
+        record = self.get_record(agent_a, agent_b)
+
+        if outcome == "win":
+            record.wins += 1
+            if agent_a_side == 0:
+                record.wins_as_side_0 += 1
+            else:
+                record.wins_as_side_1 += 1
+        elif outcome == "loss":
+            record.losses += 1
+            if agent_a_side == 0:
+                record.losses_as_side_0 += 1
+            else:
+                record.losses_as_side_1 += 1
+        else:  # draw
+            record.draws += 1
+            if agent_a_side == 0:
+                record.draws_as_side_0 += 1
+            else:
+                record.draws_as_side_1 += 1
+
+        # Track agents
+        if agent_a not in self.agents:
+            self.agents.append(agent_a)
+        if agent_b not in self.agents:
+            self.agents.append(agent_b)
+
+    def get_win_rate(self, agent_a: str, agent_b: str, side_balanced: bool = False) -> float:
+        """Get win rate of agent_a against agent_b.
+
+        Parameters
+        ----------
+        agent_a:
+            Row agent name.
+        agent_b:
+            Column agent name.
+        side_balanced:
+            If True, average win rate across both starting positions.
+
+        Returns
+        -------
+        float
+            Win rate (0.0 to 1.0), or NaN for self-play.
+        """
+        if agent_a == agent_b:
+            return float("nan")
+
+        record = self.get_record(agent_a, agent_b)
+        reverse = self.get_record(agent_b, agent_a)
+
+        if side_balanced:
+            # Average win rate across both positions
+            # Position 1: agent_a vs agent_b (agent_a as side 0/1)
+            # Position 2: agent_b vs agent_a (agent_b as side 0/1)
+            # We need to compute the average from both perspectives
+
+            # Games where agent_a was the row agent
+            games_a = record.games
+            wins_a = record.wins + 0.5 * record.draws
+
+            # Games where agent_b was the row agent (agent_a was column)
+            games_b = reverse.games
+            wins_b = reverse.wins + 0.5 * reverse.draws  # wins for agent_b
+
+            total_games = games_a + games_b
+            if total_games == 0:
+                return float("nan")
+
+            # agent_a's wins from games_a, agent_b's losses from games_b
+            agent_a_wins = wins_a + (games_b - wins_b)
+            return agent_a_wins / total_games
+        else:
+            if record.games == 0:
+                # Check reverse direction
+                if reverse.games == 0:
+                    return float("nan")
+                return 1.0 - reverse.win_rate
+            return record.win_rate
+
+    def get_sample_count(self, agent_a: str, agent_b: str) -> int:
+        """Get total number of games between agent_a and agent_b."""
+        if agent_a == agent_b:
+            return 0
+        record = self.get_record(agent_a, agent_b)
+        reverse = self.get_record(agent_b, agent_a)
+        return record.games + reverse.games
+
+    def to_matrix(self, side_balanced: bool = False) -> list[list[float]]:
+        """Return the matchup matrix as a 2D list of win rates.
+
+        Row i, column j gives win rate of agents[i] vs agents[j].
+        Diagonal is NaN.
+        """
+        sorted_agents = sorted(self.agents)
+        matrix = []
+        for agent_a in sorted_agents:
+            row = []
+            for agent_b in sorted_agents:
+                row.append(self.get_win_rate(agent_a, agent_b, side_balanced))
+            matrix.append(row)
+        return matrix
+
+    def to_numpy(self, side_balanced: bool = False) -> np.ndarray:
+        """Return the matchup matrix as a numpy array."""
+        return np.array(self.to_matrix(side_balanced))
+
+    def to_sample_matrix(self) -> list[list[int]]:
+        """Return sample count matrix as a 2D list."""
+        sorted_agents = sorted(self.agents)
+        matrix = []
+        for agent_a in sorted_agents:
+            row = []
+            for agent_b in sorted_agents:
+                row.append(self.get_sample_count(agent_a, agent_b))
+            matrix.append(row)
+        return matrix
+
+    def to_dict(self, side_balanced: bool = False) -> dict[str, Any]:
+        """Serialize to a dictionary suitable for CSV export."""
+        sorted_agents = sorted(self.agents)
+        matrix = self.to_matrix(side_balanced)
+
+        # Build detailed records
+        records_dict = {}
+        for (a, b), record in self._records.items():
+            records_dict[f"{a}_vs_{b}"] = record.to_dict()
+
+        return {
+            "game": self.game,
+            "agents": sorted_agents,
+            "matrix": matrix,
+            "records": records_dict,
+        }
+
+
+# ---------------------------------------------------------------------------
+# CSV Loading and Matrix Computation
+# ---------------------------------------------------------------------------
+
+
+def load_results_from_csv(path: str | Path) -> list[dict[str, Any]]:
+    """Load results from a CSV file in canonical arena format.
+
+    Parameters
+    ----------
+    path:
+        Path to the CSV file.
+
+    Returns
+    -------
+    list[dict]
+        List of row dictionaries with canonical column names.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Results file not found: {path}")
+
+    with open(path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        return list(reader)
+
+
+def row_to_outcome(row: dict[str, Any]) -> tuple[str, str, str, int]:
+    """Extract agent names, outcome, and side from a CSV row.
+
+    Parameters
+    ----------
+    row:
+        Dictionary with canonical column names from the CSV.
+
+    Returns
+    -------
+    tuple[str, str, str, int]
+        (agent_a, agent_b, outcome, agent_a_side) where outcome is "win", "loss", or "draw".
+    """
+    agent_a = row.get("agent_a", "")
+    agent_b = row.get("agent_b", "")
+
+    # Determine outcome from winner field
+    winner_raw = row.get("winner", "")
+    is_draw = row.get("is_draw", "").lower() == "true" or winner_raw == ""
+
+    if is_draw:
+        outcome = "draw"
+    elif winner_raw == agent_a:
+        outcome = "win"
+    else:
+        outcome = "loss"
+
+    # Get side information
+    try:
+        agent_a_side = int(row.get("agent_a_side", 0))
+    except (ValueError, TypeError):
+        agent_a_side = 0
+
+    return agent_a, agent_b, outcome, agent_a_side
+
+
+def compute_matchup_matrix(
+    results: list[dict[str, Any]],
+    game: str = "",
+    game_filter: str | None = None,
+) -> MatchupMatrix:
+    """Compute a matchup matrix from loaded CSV results.
+
+    Parameters
+    ----------
+    results:
+        List of row dictionaries from CSV files.
+    game:
+        Optional game name to include in the matrix metadata.
+    game_filter:
+        If provided, only include results for this game.
+
+    Returns
+    -------
+    MatchupMatrix
+        Pairwise matchup matrix with win rates.
+    """
+    matrix = MatchupMatrix(game=game)
+
+    for row in results:
+        # Apply game filter
+        if game_filter:
+            row_game = row.get("game", "")
+            if row_game != game_filter:
+                continue
+
+        agent_a, agent_b, outcome, agent_a_side = row_to_outcome(row)
+        if agent_a and agent_b:
+            matrix.add_result(agent_a, agent_b, outcome, agent_a_side)
+
+    return matrix
+
+
+def compute_matchup_matrix_from_csv(
+    *csv_paths: str | Path,
+    game_filter: str | None = None,
+) -> MatchupMatrix:
+    """Load results from CSV files and compute the matchup matrix.
+
+    Parameters
+    ----------
+    *csv_paths:
+        One or more paths to CSV files with match results.
+    game_filter:
+        If provided, only include results for this game.
+
+    Returns
+    -------
+    MatchupMatrix
+        Pairwise matchup matrix with win rates.
+    """
+    all_results: list[dict[str, Any]] = []
+    game = ""
+
+    for path in csv_paths:
+        path = Path(path)
+        results = load_results_from_csv(path)
+        all_results.extend(results)
+
+        # Extract game name from first result if not set
+        if not game and results:
+            game = results[0].get("game", "")
+
+    return compute_matchup_matrix(all_results, game=game, game_filter=game_filter)
+
+
+# ---------------------------------------------------------------------------
+# Plotting
+# ---------------------------------------------------------------------------
+
+
+def plot_heatmap(
+    matrix: MatchupMatrix,
+    output_path: str | Path,
+    side_balanced: bool = False,
+    annotate: bool = True,
+    show_samples: bool = False,
+    title: str | None = None,
+    figsize: tuple[int, int] | None = None,
+) -> None:
+    """Plot the matchup heatmap and save to file.
+
+    Parameters
+    ----------
+    matrix:
+        MatchupMatrix with win rate data.
+    output_path:
+        Path to save the PNG file.
+    side_balanced:
+        If True, use side-balanced win rates.
+    annotate:
+        If True, annotate cells with win rate values.
+    show_samples:
+        If True, show sample size (n=X) below win rate.
+    title:
+        Custom title for the plot.
+    figsize:
+        Figure size as (width, height).
+    """
+    try:
+        import matplotlib.pyplot as plt
+        import seaborn as sns
+    except ImportError as exc:
+        raise ImportError(
+            "matplotlib and seaborn are required for plotting. "
+            "Install them with: pip install -e '.[analysis]'"
+        ) from exc
+
+    sorted_agents = sorted(matrix.agents)
+    n = len(sorted_agents)
+
+    if n == 0:
+        print("No agents found in the data.")
+        return
+
+    # Get win rate matrix
+    win_rates = np.array(matrix.to_matrix(side_balanced))
+
+    # Get sample count matrix if needed
+    sample_counts = None
+    if show_samples:
+        sample_counts = np.array(matrix.to_sample_matrix())
+
+    # Determine figure size
+    if figsize is None:
+        size = max(8, n + 2)
+        figsize = (size, size - 1)
+
+    # Create figure
+    fig, ax = plt.subplots(figsize=figsize)
+
+    # Use RdYlGn colormap centered at 0.5 (diverging)
+    cmap = sns.diverging_palette(10, 130, s=90, l=50, as_cmap=True)
+
+    # Create heatmap mask for diagonal (NaN values)
+    mask = np.isnan(win_rates)
+
+    # Plot heatmap
+    sns.heatmap(
+        win_rates,
+        annot=False,  # We'll add custom annotations
+        cmap=cmap,
+        center=0.5,
+        vmin=0,
+        vmax=1,
+        square=True,
+        mask=mask,
+        cbar_kws={"label": "Win Rate (row vs column)"},
+        ax=ax,
+        linewidths=0.5,
+        linecolor="gray",
+    )
+
+    # Set axis labels
+    ax.set_xticks(np.arange(n) + 0.5)
+    ax.set_yticks(np.arange(n) + 0.5)
+    ax.set_xticklabels(sorted_agents, rotation=45, ha="right", fontsize=10)
+    ax.set_yticklabels(sorted_agents, rotation=0, fontsize=10)
+
+    # Set title
+    if title is None:
+        game_name = matrix.game or "All Games"
+        balance_str = " (side-balanced)" if side_balanced else ""
+        title = f"Agent vs Agent Win Rates{balance_str}\n{game_name}"
+    ax.set_title(title, fontsize=14, fontweight="bold", pad=20)
+
+    # Axis labels
+    ax.set_xlabel("Opponent (column)", fontsize=12)
+    ax.set_ylabel("Agent (row)", fontsize=12)
+
+    # Add custom annotations
+    if annotate:
+        for i in range(n):
+            for j in range(n):
+                if mask[i, j]:
+                    # Gray out diagonal
+                    ax.add_patch(plt.Rectangle((j, i), 1, 1, fill=True, color="#e0e0e0", lw=0))
+                    ax.text(
+                        j + 0.5,
+                        i + 0.5,
+                        "—",
+                        ha="center",
+                        va="center",
+                        fontsize=10,
+                        color="gray",
+                    )
+                else:
+                    win_rate = win_rates[i, j]
+                    if not np.isnan(win_rate):
+                        # Main annotation: win rate percentage
+                        text = f"{win_rate:.0%}"
+
+                        # Add sample count if requested
+                        if show_samples and sample_counts is not None:
+                            n_samples = sample_counts[i, j]
+                            if n_samples > 0:
+                                text += f"\nn={n_samples}"
+
+                        # Choose text color based on background
+                        text_color = "white" if 0.3 < win_rate < 0.7 else "black"
+
+                        ax.text(
+                            j + 0.5,
+                            i + 0.5,
+                            text,
+                            ha="center",
+                            va="center",
+                            fontsize=9 if show_samples else 10,
+                            color=text_color,
+                            fontweight="bold" if not show_samples else "normal",
+                        )
+
+    plt.tight_layout()
+
+    # Save figure
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=150, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+
+    print(f"Saved heatmap to {output_path}")
+
+
+def save_matrix_csv(
+    matrix: MatchupMatrix,
+    output_path: str | Path,
+    side_balanced: bool = False,
+) -> None:
+    """Save the matchup matrix to a CSV file.
+
+    Parameters
+    ----------
+    matrix:
+        MatchupMatrix with win rate data.
+    output_path:
+        Path to save the CSV file.
+    side_balanced:
+        If True, use side-balanced win rates.
+    """
+    sorted_agents = sorted(matrix.agents)
+    win_rates = matrix.to_matrix(side_balanced)
+
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(output_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+
+        # Header row
+        writer.writerow(["Agent"] + sorted_agents)
+
+        # Data rows
+        for i, agent in enumerate(sorted_agents):
+            row = [agent]
+            for j, _ in enumerate(sorted_agents):
+                val = win_rates[i][j]
+                if isinstance(val, float) and (val != val):  # NaN check
+                    row.append("")
+                else:
+                    row.append(f"{val:.4f}")
+            writer.writerow(row)
+
+    print(f"Saved matrix CSV to {output_path}")
+
+
+# ---------------------------------------------------------------------------
+# CLI Entry Point
+# ---------------------------------------------------------------------------
+
+
+def expand_glob_paths(patterns: list[str]) -> list[str]:
+    """Expand glob patterns to actual file paths.
+
+    Parameters
+    ----------
+    patterns:
+        List of file paths or glob patterns.
+
+    Returns
+    -------
+    list[str]
+        Expanded list of file paths.
+    """
+    from glob import glob
+
+    expanded: list[str] = []
+    for pattern in patterns:
+        # Check if it's a glob pattern
+        if "*" in pattern or "?" in pattern:
+            matches = sorted(glob(pattern))
+            expanded.extend(matches)
+        else:
+            expanded.append(pattern)
+
+    return expanded
+
+
+def main(args: list[str] | None = None) -> int:
+    """CLI entry point for plotting matchup heatmap.
+
+    Usage:
+        python3 scripts/plot_matchup_heatmap.py results/*.csv
+        python3 scripts/plot_matchup_heatmap.py results/*.csv --output-dir output/
+        python3 scripts/plot_matchup_heatmap.py results/*.csv --game breakthrough
+        python3 scripts/plot_matchup_heatmap.py results/*.csv --no-annotate
+        python3 scripts/plot_matchup_heatmap.py results/*.csv --show-samples
+        python3 scripts/plot_matchup_heatmap.py results/*.csv --side-balanced
+
+    Parameters
+    ----------
+    args:
+        Command line arguments (defaults to sys.argv[1:]).
+
+    Returns
+    -------
+    int
+        Exit code (0 for success, 1 for error).
+    """
+    parser = argparse.ArgumentParser(
+        description="Generate agent vs agent win rate heatmap",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python3 scripts/plot_matchup_heatmap.py results/*.csv
+  python3 scripts/plot_matchup_heatmap.py results/*.csv --game breakthrough
+  python3 scripts/plot_matchup_heatmap.py results/*.csv --output-dir output/
+  python3 scripts/plot_matchup_heatmap.py results/*.csv --side-balanced --show-samples
+""",
+    )
+
+    parser.add_argument(
+        "csv_paths",
+        nargs="+",
+        help="One or more CSV file paths (supports glob patterns)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="output/",
+        help="Output directory for PNG and CSV files (default: output/)",
+    )
+    parser.add_argument(
+        "--game",
+        type=str,
+        default=None,
+        help="Filter results to a specific game",
+    )
+    parser.add_argument(
+        "--no-annotate",
+        action="store_true",
+        default=False,
+        help="Disable cell annotations (default: annotations on)",
+    )
+    parser.add_argument(
+        "--show-samples",
+        action="store_true",
+        help="Show sample size (n=X) in cells",
+    )
+    parser.add_argument(
+        "--side-balanced",
+        action="store_true",
+        help="Use side-balanced win rate aggregation",
+    )
+
+    parsed = parser.parse_args(args)
+
+    # Expand glob patterns
+    csv_paths = expand_glob_paths(parsed.csv_paths)
+
+    if not csv_paths:
+        print("Error: No CSV files found.", file=sys.stderr)
+        return 1
+
+    # Verify files exist
+    for path in csv_paths:
+        if not Path(path).exists():
+            print(f"Error: File not found: {path}", file=sys.stderr)
+            return 1
+
+    print(f"Processing {len(csv_paths)} CSV file(s)...")
+
+    try:
+        # Compute matchup matrix
+        matrix = compute_matchup_matrix_from_csv(*csv_paths, game_filter=parsed.game)
+
+        if not matrix.agents:
+            print("Error: No agents found in the data.", file=sys.stderr)
+            return 1
+
+        print(f"Found {len(matrix.agents)} agents: {', '.join(sorted(matrix.agents))}")
+
+        # Create output directory
+        output_dir = Path(parsed.output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        # Generate output filenames
+        game_suffix = f"_{parsed.game}" if parsed.game else ""
+        balance_suffix = "_side_balanced" if parsed.side_balanced else ""
+        png_path = output_dir / f"matchup_heatmap{game_suffix}{balance_suffix}.png"
+        csv_path = output_dir / f"matchup_matrix{game_suffix}{balance_suffix}.csv"
+
+        # Plot heatmap
+        plot_heatmap(
+            matrix,
+            output_path=png_path,
+            side_balanced=parsed.side_balanced,
+            annotate=not parsed.no_annotate,
+            show_samples=parsed.show_samples,
+        )
+
+        # Save matrix CSV
+        save_matrix_csv(
+            matrix,
+            output_path=csv_path,
+            side_balanced=parsed.side_balanced,
+        )
+
+        print(f"\nDone! Generated:")
+        print(f"  - {png_path}")
+        print(f"  - {csv_path}")
+
+        return 0
+
+    except Exception as e:
+        print(f"Error processing files: {e}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_matchup_heatmap.py
+++ b/tests/test_matchup_heatmap.py
@@ -1,0 +1,498 @@
+"""
+Tests for scripts.plot_matchup_heatmap module.
+"""
+
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from scripts.plot_matchup_heatmap import (
+    MatchupMatrix,
+    MatchupRecord,
+    compute_matchup_matrix,
+    compute_matchup_matrix_from_csv,
+    expand_glob_paths,
+    load_results_from_csv,
+    main,
+    row_to_outcome,
+    save_matrix_csv,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_csv(tmp_path: Path) -> Path:
+    """Create a sample CSV file for testing."""
+    csv_content = """run_id,game,agent_a,agent_b,agent_a_side,agent_b_side,winner,is_draw,num_moves,seed,invalid_move_retries,agent_a_latency_ms,agent_b_latency_ms,termination_reason
+id1,breakthrough,alice,bob,0,1,alice,False,10,,0,0,0,normal
+id2,breakthrough,alice,bob,0,1,bob,False,12,,0,0,0,normal
+id3,breakthrough,alice,charlie,0,1,alice,False,8,,0,0,0,normal
+id4,breakthrough,bob,charlie,0,1,bob,False,15,,0,0,0,normal
+id5,breakthrough,charlie,alice,1,0,alice,False,20,,0,0,0,normal
+id6,tic_tac_toe,alice,bob,0,1,,True,9,,0,0,0,normal
+"""
+    csv_file = tmp_path / "test_results.csv"
+    csv_file.write_text(csv_content)
+    return csv_file
+
+
+@pytest.fixture
+def multi_game_csv(tmp_path: Path) -> Path:
+    """Create a CSV with multiple games."""
+    csv_content = """run_id,game,agent_a,agent_b,agent_a_side,agent_b_side,winner,is_draw,num_moves,seed,invalid_move_retries,agent_a_latency_ms,agent_b_latency_ms,termination_reason
+id1,breakthrough,alice,bob,0,1,alice,False,10,,0,0,0,normal
+id2,breakthrough,bob,alice,0,1,bob,False,12,,0,0,0,normal
+id3,tic_tac_toe,alice,bob,0,1,alice,False,8,,0,0,0,normal
+id4,tic_tac_toe,bob,alice,0,1,alice,False,15,,0,0,0,normal
+"""
+    csv_file = tmp_path / "multi_game.csv"
+    csv_file.write_text(csv_content)
+    return csv_file
+
+
+# ---------------------------------------------------------------------------
+# Test MatchupRecord
+# ---------------------------------------------------------------------------
+
+
+class TestMatchupRecord:
+    """Tests for MatchupRecord dataclass."""
+
+    def test_empty_record(self) -> None:
+        """Empty record should have zero games and win rate."""
+        record = MatchupRecord()
+        assert record.games == 0
+        assert record.win_rate == 0.0
+
+    def test_wins_only(self) -> None:
+        """Record with only wins."""
+        record = MatchupRecord(wins=10)
+        assert record.games == 10
+        assert record.win_rate == 1.0
+
+    def test_losses_only(self) -> None:
+        """Record with only losses."""
+        record = MatchupRecord(losses=10)
+        assert record.games == 10
+        assert record.win_rate == 0.0
+
+    def test_draws_only(self) -> None:
+        """Record with only draws should have 0.5 win rate."""
+        record = MatchupRecord(draws=10)
+        assert record.games == 10
+        assert record.win_rate == 0.5
+
+    def test_mixed_record(self) -> None:
+        """Mixed win/loss/draw record."""
+        record = MatchupRecord(wins=6, losses=2, draws=2)
+        assert record.games == 10
+        # Win rate: (6 + 0.5 * 2) / 10 = 0.7
+        assert record.win_rate == 0.7
+
+    def test_side_tracking(self) -> None:
+        """Side tracking attributes exist."""
+        record = MatchupRecord(wins=5, wins_as_side_0=3, wins_as_side_1=2)
+        assert record.wins_as_side_0 == 3
+        assert record.wins_as_side_1 == 2
+
+
+# ---------------------------------------------------------------------------
+# Test MatchupMatrix
+# ---------------------------------------------------------------------------
+
+
+class TestMatchupMatrix:
+    """Tests for MatchupMatrix class."""
+
+    def test_empty_matrix(self) -> None:
+        """Empty matrix should have no agents."""
+        matrix = MatchupMatrix()
+        assert matrix.agents == []
+
+    def test_add_win_result(self) -> None:
+        """Adding a win result."""
+        matrix = MatchupMatrix()
+        matrix.add_result("alice", "bob", "win")
+        assert "alice" in matrix.agents
+        assert "bob" in matrix.agents
+        assert matrix.get_win_rate("alice", "bob") == 1.0
+        assert matrix.get_win_rate("bob", "alice") == 0.0
+
+    def test_diagonal_is_nan(self) -> None:
+        """Diagonal entries should be NaN (no self-play)."""
+        matrix = MatchupMatrix()
+        matrix.add_result("alice", "bob", "win")
+
+        # Self-play should return NaN
+        win_rate = matrix.get_win_rate("alice", "alice")
+        assert isinstance(win_rate, float)
+        assert win_rate != win_rate  # NaN check
+
+    def test_matrix_diagonal_nan(self) -> None:
+        """Matrix diagonal should contain NaN values."""
+        matrix = MatchupMatrix()
+        matrix.add_result("alice", "bob", "win")
+        matrix.add_result("bob", "charlie", "loss")
+
+        mat = matrix.to_matrix()
+        agents = sorted(matrix.agents)
+
+        # All diagonal elements should be NaN
+        for i, agent in enumerate(agents):
+            assert np.isnan(mat[i][i])
+
+    def test_side_balanced_aggregation(self) -> None:
+        """Side-balanced aggregation averages across positions."""
+        matrix = MatchupMatrix()
+
+        # alice beats bob when alice is row agent (1 game)
+        matrix.add_result("alice", "bob", "win", agent_a_side=0)
+
+        # bob beats alice when bob is row agent (1 game)
+        # This means alice lost when she was column agent
+        matrix.add_result("bob", "alice", "win", agent_a_side=0)
+
+        # Without side-balancing:
+        # alice vs bob: 1 win in 1 game = 1.0
+        assert matrix.get_win_rate("alice", "bob", side_balanced=False) == 1.0
+
+        # With side-balancing:
+        # alice has 1 win as row, 0 wins as column (1 loss)
+        # Total: 1 win out of 2 games = 0.5
+        assert matrix.get_win_rate("alice", "bob", side_balanced=True) == 0.5
+
+    def test_side_balanced_with_multiple_games(self) -> None:
+        """Side-balanced with multiple games per position."""
+        matrix = MatchupMatrix()
+
+        # alice vs bob: 3 wins, 1 loss as row agent
+        matrix.add_result("alice", "bob", "win", agent_a_side=0)
+        matrix.add_result("alice", "bob", "win", agent_a_side=0)
+        matrix.add_result("alice", "bob", "win", agent_a_side=0)
+        matrix.add_result("alice", "bob", "loss", agent_a_side=0)
+
+        # bob vs alice: 2 wins, 2 losses (alice wins 2 as column)
+        matrix.add_result("bob", "alice", "win", agent_a_side=0)
+        matrix.add_result("bob", "alice", "win", agent_a_side=0)
+        matrix.add_result("bob", "alice", "loss", agent_a_side=0)
+        matrix.add_result("bob", "alice", "loss", agent_a_side=0)
+
+        # Side-balanced: alice has 3+2=5 wins out of 8 games = 0.625
+        win_rate = matrix.get_win_rate("alice", "bob", side_balanced=True)
+        assert win_rate == pytest.approx(5 / 8)
+
+    def test_get_sample_count(self) -> None:
+        """Sample count sums games from both directions."""
+        matrix = MatchupMatrix()
+
+        # 3 games alice vs bob
+        matrix.add_result("alice", "bob", "win")
+        matrix.add_result("alice", "bob", "win")
+        matrix.add_result("alice", "bob", "loss")
+
+        # 2 games bob vs alice
+        matrix.add_result("bob", "alice", "win")
+        matrix.add_result("bob", "alice", "loss")
+
+        # Total: 5 games
+        assert matrix.get_sample_count("alice", "bob") == 5
+        assert matrix.get_sample_count("bob", "alice") == 5
+
+    def test_sample_count_self_play_zero(self) -> None:
+        """Sample count for self-play should be 0."""
+        matrix = MatchupMatrix()
+        matrix.add_result("alice", "bob", "win")
+
+        assert matrix.get_sample_count("alice", "alice") == 0
+
+    def test_to_numpy(self) -> None:
+        """Conversion to numpy array."""
+        matrix = MatchupMatrix()
+        matrix.add_result("alice", "bob", "win")
+        matrix.add_result("bob", "charlie", "win")
+
+        arr = matrix.to_numpy()
+        assert isinstance(arr, np.ndarray)
+        assert arr.shape == (3, 3)
+
+    def test_to_sample_matrix(self) -> None:
+        """Sample count matrix generation."""
+        matrix = MatchupMatrix()
+        matrix.add_result("alice", "bob", "win")
+        matrix.add_result("alice", "bob", "win")
+        matrix.add_result("bob", "alice", "win")
+
+        sample_matrix = matrix.to_sample_matrix()
+        # 3 total games
+        assert sample_matrix[0][1] == 3  # alice vs bob
+        assert sample_matrix[1][0] == 3  # bob vs alice
+
+
+# ---------------------------------------------------------------------------
+# Test row_to_outcome
+# ---------------------------------------------------------------------------
+
+
+class TestRowToOutcome:
+    """Tests for row_to_outcome function."""
+
+    def test_win_outcome(self) -> None:
+        """Win when agent_a is the winner."""
+        row = {"agent_a": "alice", "agent_b": "bob", "winner": "alice", "is_draw": "False", "agent_a_side": "0"}
+        agent_a, agent_b, outcome, side = row_to_outcome(row)
+        assert agent_a == "alice"
+        assert agent_b == "bob"
+        assert outcome == "win"
+        assert side == 0
+
+    def test_loss_outcome(self) -> None:
+        """Loss when agent_b is the winner."""
+        row = {"agent_a": "alice", "agent_b": "bob", "winner": "bob", "is_draw": "False", "agent_a_side": "1"}
+        _, _, outcome, side = row_to_outcome(row)
+        assert outcome == "loss"
+        assert side == 1
+
+    def test_draw_outcome(self) -> None:
+        """Draw when is_draw is True."""
+        row = {"agent_a": "alice", "agent_b": "bob", "winner": "", "is_draw": "True", "agent_a_side": "0"}
+        _, _, outcome, _ = row_to_outcome(row)
+        assert outcome == "draw"
+
+
+# ---------------------------------------------------------------------------
+# Test CSV Loading
+# ---------------------------------------------------------------------------
+
+
+class TestCSVLoading:
+    """Tests for CSV loading functions."""
+
+    def test_load_results_from_csv(self, sample_csv: Path) -> None:
+        """Load results from a CSV file."""
+        results = load_results_from_csv(sample_csv)
+        assert len(results) == 6
+        assert results[0]["agent_a"] == "alice"
+        assert results[0]["game"] == "breakthrough"
+
+    def test_load_nonexistent_file(self) -> None:
+        """Loading a nonexistent file should raise FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            load_results_from_csv("/nonexistent/file.csv")
+
+    def test_compute_from_csv(self, sample_csv: Path) -> None:
+        """Compute matchup matrix directly from CSV file."""
+        matrix = compute_matchup_matrix_from_csv(str(sample_csv))
+
+        assert len(matrix.agents) == 3
+        assert "alice" in matrix.agents
+        assert "bob" in matrix.agents
+        assert "charlie" in matrix.agents
+
+    def test_game_filter(self, sample_csv: Path) -> None:
+        """Game filter should exclude non-matching games."""
+        matrix = compute_matchup_matrix_from_csv(str(sample_csv), game_filter="breakthrough")
+
+        # The draw (id6) is from tic_tac_toe, should be excluded
+        # Check that we only have breakthrough games
+        assert matrix.game == "breakthrough"
+
+
+# ---------------------------------------------------------------------------
+# Test CLI
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    """Tests for CLI functionality."""
+
+    def test_main_basic(self, sample_csv: Path, tmp_path: Path) -> None:
+        """Basic CLI run should create output files."""
+        output_dir = tmp_path / "output"
+        result = main([str(sample_csv), "--output-dir", str(output_dir)])
+
+        assert result == 0
+        assert (output_dir / "matchup_heatmap.png").exists()
+        assert (output_dir / "matchup_matrix.csv").exists()
+
+    def test_main_with_game_filter(self, multi_game_csv: Path, tmp_path: Path) -> None:
+        """Game filter should create appropriately named output."""
+        output_dir = tmp_path / "output"
+        result = main([str(multi_game_csv), "--output-dir", str(output_dir), "--game", "breakthrough"])
+
+        assert result == 0
+        assert (output_dir / "matchup_heatmap_breakthrough.png").exists()
+        assert (output_dir / "matchup_matrix_breakthrough.csv").exists()
+
+    def test_main_side_balanced(self, sample_csv: Path, tmp_path: Path) -> None:
+        """Side-balanced flag should create appropriately named output."""
+        output_dir = tmp_path / "output"
+        result = main([str(sample_csv), "--output-dir", str(output_dir), "--side-balanced"])
+
+        assert result == 0
+        assert (output_dir / "matchup_heatmap_side_balanced.png").exists()
+        assert (output_dir / "matchup_matrix_side_balanced.csv").exists()
+
+    def test_main_no_annotate(self, sample_csv: Path, tmp_path: Path) -> None:
+        """No-annotate flag should run without error."""
+        output_dir = tmp_path / "output"
+        result = main([str(sample_csv), "--output-dir", str(output_dir), "--no-annotate"])
+
+        assert result == 0
+        assert (output_dir / "matchup_heatmap.png").exists()
+
+    def test_main_show_samples(self, sample_csv: Path, tmp_path: Path) -> None:
+        """Show-samples flag should run without error."""
+        output_dir = tmp_path / "output"
+        result = main([str(sample_csv), "--output-dir", str(output_dir), "--show-samples"])
+
+        assert result == 0
+        assert (output_dir / "matchup_heatmap.png").exists()
+
+    def test_main_nonexistent_file(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+        """Nonexistent file should return error."""
+        output_dir = tmp_path / "output"
+        result = main(["/nonexistent/file.csv", "--output-dir", str(output_dir)])
+
+        assert result == 1
+        captured = capsys.readouterr()
+        assert "Error" in captured.err
+
+    def test_main_multiple_files(self, tmp_path: Path) -> None:
+        """Multiple CSV files should be combined."""
+        # Create two CSV files
+        csv1 = tmp_path / "test1.csv"
+        csv1.write_text("""run_id,game,agent_a,agent_b,agent_a_side,agent_b_side,winner,is_draw,num_moves,seed,invalid_move_retries,agent_a_latency_ms,agent_b_latency_ms,termination_reason
+id1,test,alice,bob,0,1,alice,False,10,,0,0,0,normal
+""")
+        csv2 = tmp_path / "test2.csv"
+        csv2.write_text("""run_id,game,agent_a,agent_b,agent_a_side,agent_b_side,winner,is_draw,num_moves,seed,invalid_move_retries,agent_a_latency_ms,agent_b_latency_ms,termination_reason
+id2,test,bob,charlie,0,1,bob,False,10,,0,0,0,normal
+""")
+
+        output_dir = tmp_path / "output"
+        result = main([str(csv1), str(csv2), "--output-dir", str(output_dir)])
+
+        assert result == 0
+
+
+# ---------------------------------------------------------------------------
+# Test save_matrix_csv
+# ---------------------------------------------------------------------------
+
+
+class TestSaveMatrixCSV:
+    """Tests for save_matrix_csv function."""
+
+    def test_save_csv_output(self, tmp_path: Path) -> None:
+        """CSV output should have correct format."""
+        matrix = MatchupMatrix(game="test_game")
+        matrix.add_result("alice", "bob", "win")
+        matrix.add_result("bob", "charlie", "loss")
+
+        output_path = tmp_path / "matrix.csv"
+        save_matrix_csv(matrix, output_path)
+
+        content = output_path.read_text()
+        lines = content.strip().split("\n")
+
+        # Header + 3 agents = 4 lines
+        assert len(lines) == 4
+        # Header should have Agent + agent names
+        assert "Agent" in lines[0]
+        assert "alice" in lines[0]
+        assert "bob" in lines[0]
+        assert "charlie" in lines[0]
+
+    def test_save_csv_diagonal_empty(self, tmp_path: Path) -> None:
+        """Diagonal cells should be empty in CSV."""
+        matrix = MatchupMatrix(game="test_game")
+        matrix.add_result("alice", "bob", "win")
+
+        output_path = tmp_path / "matrix.csv"
+        save_matrix_csv(matrix, output_path)
+
+        content = output_path.read_text()
+        lines = content.strip().split("\n")
+
+        # Find alice row and check diagonal is empty
+        # Agents are sorted: alice, bob
+        # alice row: alice, "", "1.0000" (diagonal empty, vs bob is 1.0)
+        alice_row = lines[1].split(",")
+        assert alice_row[1] == ""  # Diagonal is empty
+
+
+# ---------------------------------------------------------------------------
+# Test expand_glob_paths
+# ---------------------------------------------------------------------------
+
+
+class TestExpandGlobPaths:
+    """Tests for expand_glob_paths function."""
+
+    def test_no_expansion_needed(self, tmp_path: Path) -> None:
+        """Non-glob paths should pass through."""
+        file1 = tmp_path / "file1.csv"
+        file2 = tmp_path / "file2.csv"
+        file1.touch()
+        file2.touch()
+
+        result = expand_glob_paths([str(file1), str(file2)])
+        assert len(result) == 2
+        assert str(file1) in result
+        assert str(file2) in result
+
+    def test_glob_expansion(self, tmp_path: Path) -> None:
+        """Glob patterns should be expanded."""
+        file1 = tmp_path / "file1.csv"
+        file2 = tmp_path / "file2.csv"
+        file1.touch()
+        file2.touch()
+
+        pattern = str(tmp_path / "*.csv")
+        result = expand_glob_paths([pattern])
+
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# Integration Tests
+# ---------------------------------------------------------------------------
+
+
+class TestIntegration:
+    """Integration tests for the full workflow."""
+
+    def test_full_workflow(self, tmp_path: Path) -> None:
+        """Test the full workflow from CSV to outputs."""
+        # Create test data
+        csv_content = """run_id,game,agent_a,agent_b,agent_a_side,agent_b_side,winner,is_draw,num_moves,seed,invalid_move_retries,agent_a_latency_ms,agent_b_latency_ms,termination_reason
+id1,breakthrough,mcts-100,random,0,1,mcts-100,False,20,,0,100,0,normal
+id2,breakthrough,mcts-100,random,0,1,mcts-100,False,15,,0,100,0,normal
+id3,breakthrough,random,mcts-100,0,1,mcts-100,False,25,,0,0,100,normal
+id4,breakthrough,mcts-500,random,0,1,mcts-500,False,18,,0,500,0,normal
+id5,breakthrough,mcts-100,mcts-500,0,1,mcts-500,False,30,,0,100,500,normal
+id6,breakthrough,mcts-500,mcts-100,0,1,mcts-500,False,28,,0,500,100,normal
+"""
+        csv_file = tmp_path / "results.csv"
+        csv_file.write_text(csv_content)
+
+        output_dir = tmp_path / "output"
+
+        # Run the CLI
+        result = main([str(csv_file), "--output-dir", str(output_dir), "--show-samples"])
+
+        assert result == 0
+        assert (output_dir / "matchup_heatmap.png").exists()
+        assert (output_dir / "matchup_matrix.csv").exists()
+
+        # Verify CSV content
+        matrix_csv = (output_dir / "matchup_matrix.csv").read_text()
+        assert "mcts-100" in matrix_csv
+        assert "mcts-500" in matrix_csv
+        assert "random" in matrix_csv


### PR DESCRIPTION
## Summary

Implements GitHub issue #10: a heatmap showing pairwise win rates between agents.

## Changes

- **`scripts/plot_matchup_heatmap.py`** — standalone CLI script:
  - Accepts one or more CSV paths (glob-friendly)
  - Optional `--output-dir` (default: `output/`)
  - Optional `--game` filter
  - Optional `--no-annotate` to disable cell annotations
  - Optional `--show-samples` to show sample sizes
  - Optional `--side-balanced` for side-balanced aggregation
  - Outputs PNG heatmap and CSV matrix

- **`analysis/matchup_heatmap.ipynb`** — Jupyter notebook:
  - Demonstrates how to load results, build the matrix, and render the heatmap
  - Includes markdown explanations

- **`tests/test_matchup_heatmap.py`** — 35 tests:
  - Test matrix building with synthetic data
  - Test that diagonal is NaN
  - Test side-balanced aggregation
  - Test CLI functionality

## Test Results

```
$ .venv/bin/python -m pytest tests/test_matchup_heatmap.py -v
============================= 35 passed in 29.85s ==============================
```

## Usage

```bash
# Basic usage
python3 scripts/plot_matchup_heatmap.py results/*.csv

# With game filter and side-balanced aggregation
python3 scripts/plot_matchup_heatmap.py results/*.csv --game breakthrough --side-balanced --show-samples
```

## Generated Files

- `output/matchup_heatmap.png` - Heatmap visualization
- `output/matchup_matrix.csv` - Win rate matrix in CSV format