### PR TITLE
feat: visualize Elo leaderboard over time (#9)

### DIFF
--- a/analysis/elo_over_time.ipynb
+++ b/analysis/elo_over_time.ipynb
@@ -1,0 +1,449 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Elo Rating Evolution Over Time\n",
+    "\n",
+    "This notebook demonstrates how to visualize the evolution of agent Elo ratings over the course of a tournament.\n",
+    "\n",
+    "## What the Chart Shows\n",
+    "\n",
+    "The line chart displays the **Elo rating trajectory** for each agent:\n",
+    "\n",
+    "- **X-axis**: Match number (cumulative)\n",
+    "- **Y-axis**: Elo rating\n",
+    "- **Each line**: One agent's rating history\n",
+    "\n",
+    "### Interpreting the Chart\n",
+    "\n",
+    "- **Rising lines**: Agent is performing better than expected\n",
+    "- **Falling lines**: Agent is performing worse than expected\n",
+    "- **Flat lines**: Agent is performing at their expected level\n",
+    "- **Convergence**: Ratings may stabilize as the tournament progresses\n",
+    "\n",
+    "### Color Scheme\n",
+    "\n",
+    "Agents are colored by type:\n",
+    "- **Blue/Grey tones**: Search-based agents (random, mcts-*)\n",
+    "- **Warm tones (orange/red/yellow)**: LLM-based agents (llm-*)\n",
+    "- **Green/Purple tones**: Other agents"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# Add project root to path\n",
+    "project_root = Path(\"..\").resolve()\n",
+    "if str(project_root) not in sys.path:\n",
+    "    sys.path.insert(0, str(project_root))\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from scripts.plot_elo_over_time import (\n",
+    "    compute_elo_trajectories,\n",
+    "    load_all_results,\n",
+    "    plot_elo_over_time,\n",
+    "    save_trajectory_csv,\n",
+    "    DEFAULT_RATING,\n",
+    "    K_FACTOR,\n")"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load Results\n",
+    "\n",
+    "We'll load match results from CSV files in the `results/` directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Find all CSV result files\n",
+    "results_dir = project_root / \"results\"\n",
+    "csv_files = sorted(results_dir.glob(\"*.csv\"))\n",
+    "\n",
+    "print(f\"Found {len(csv_files)} CSV files in {results_dir}\")\n",
+    "if csv_files:\n",
+    "    print(f\"Example files: {[f.name for f in csv_files[:3]]}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load all results\n",
+    "csv_paths = [str(f) for f in csv_files]\n",
+    "all_results = load_all_results(*csv_paths)\n",
+    "\n",
+    "print(f\"Loaded {len(all_results)} match records\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Explore the Data\n",
+    "\n",
+    "Let's see what games and agents are in our dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check what games are in the data\n",
+    "games_found = set()\n",
+    "agents_found = set()\n",
+    "\n",
+    "for row in all_results:\n",
+    "    games_found.add(row.get(\"game\", \"unknown\"))\n",
+    "    agents_found.add(row.get(\"agent_a\", \"\"))\n",
+    "    agents_found.add(row.get(\"agent_b\", \"\"))\n",
+    "\n",
+    "# Remove empty strings\n",
+    "agents_found.discard(\"\")\n",
+    "\n",
+    "print(f\"Games found: {sorted(games_found)}\")\n",
+    "print(f\"Agents found ({len(agents_found)}): {sorted(agents_found)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Compute Elo Trajectories\n",
+    "\n",
+    "We compute the Elo rating trajectories by processing matches in order.\n",
+    "\n",
+    "Each agent starts at the default rating (1500) and their rating is updated after each match they play."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compute trajectories for all games\n",
+    "history = compute_elo_trajectories(\n",
+    "    all_results,\n",
+    "    k=K_FACTOR,\n",
+    "    start_rating=DEFAULT_RATING,\n",
+    ")\n",
+    "\n",
+    "print(f\"Computed trajectories for {len(history.trajectories)} agents\")\n",
+    "print(f\"Total matches processed: {history.total_matches}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Final Elo Ratings\n",
+    "\n",
+    "Let's see the final Elo ratings for all agents."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a summary DataFrame\n",
+    "summary_data = []\n",
+    "for agent, traj in history.trajectories.items():\n",
+    "    summary_data.append({\n",
+    "        \"Agent\": agent,\n",
+    "        \"Final Elo\": traj.final_rating,\n",
+    "        \"Initial Elo\": traj.ratings[0] if traj.ratings else DEFAULT_RATING,\n",
+    "        \"Change\": traj.final_rating - (traj.ratings[0] if traj.ratings else DEFAULT_RATING),\n",
+    "        \"Snapshots\": len(traj.ratings),\n",
+    "    })\n",
+    "\n",
+    "summary_df = pd.DataFrame(summary_data)\n",
+    "summary_df = summary_df.sort_values(\"Final Elo\", ascending=False)\n",
+    "summary_df.style.format({\n",
+    "    \"Final Elo\": \"{:.1f}\",\n",
+    "    \"Initial Elo\": \"{:.1f}\",\n",
+    "    \"Change\": \"{:+.1f}\",\n",
+    "}).background_gradient(subset=[\"Final Elo\"], cmap=\"RdYlGn\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Filter by Game (Optional)\n",
+    "\n",
+    "If results contain multiple games, we can filter to a specific one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Filter to a specific game (e.g., breakthrough)\n",
+    "game_filter = \"breakthrough\" if \"breakthrough\" in games_found else list(games_found)[0] if games_found else None\n",
+    "\n",
+    "if game_filter:\n",
+    "    history_filtered = compute_elo_trajectories(\n",
+    "        all_results,\n",
+    "        k=K_FACTOR,\n",
+    "        start_rating=DEFAULT_RATING,\n",
+    "        game_filter=game_filter,\n",
+    "    )\n",
+    "    print(f\"Filtered to {game_filter}: {len(history_filtered.trajectories)} agents, {history_filtered.total_matches} matches\")\n",
+    "else:\n",
+    "    history_filtered = history\n",
+    "    print(\"Using all games\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot Elo Evolution\n",
+    "\n",
+    "Now let's visualize the Elo trajectories."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create output directory\n",
+    "output_dir = project_root / \"output\"\n",
+    "output_dir.mkdir(exist_ok=True)\n",
+    "\n",
+    "# Plot the chart\n",
+    "output_path = output_dir / \"elo_over_time_notebook.png\"\n",
+    "plot_elo_over_time(\n",
+    "    history_filtered,\n",
+    "    output_path=output_path,\n",
+    ")\n",
+    "\n",
+    "# Display the image\n",
+    "from IPython.display import Image\n",
+    "Image(filename=output_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Trajectory Data\n",
+    "\n",
+    "Let's look at the raw trajectory data for a specific agent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get trajectory for top-rated agent\n",
+    "top_agent = max(history_filtered.trajectories.items(), key=lambda x: x[1].final_rating)[0]\n",
+    "top_traj = history_filtered.trajectories[top_agent]\n",
+    "\n",
+    "print(f\"Trajectory for {top_agent} (top-rated agent):\")\n",
+    "print(f\"  Initial rating: {top_traj.ratings[0]:.1f}\")\n",
+    "print(f\"  Final rating: {top_traj.final_rating:.1f}\")\n",
+    "print(f\"  Change: {top_traj.final_rating - top_traj.ratings[0]:+.1f}\")\n",
+    "print(f\"  Min rating: {min(top_traj.ratings):.1f}\")\n",
+    "print(f\"  Max rating: {max(top_traj.ratings):.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot trajectory for a single agent\n",
+    "fig, ax = plt.subplots(figsize=(10, 5))\n",
+    "\n",
+    "ax.plot(top_traj.ratings, linewidth=2, color='#2E86AB')\n",
+    "ax.axhline(y=DEFAULT_RATING, color='gray', linestyle='--', alpha=0.5, label='Initial Rating')\n",
+    "ax.set_xlabel('Match Number', fontsize=12)\n",
+    "ax.set_ylabel('Elo Rating', fontsize=12)\n",
+    "ax.set_title(f'Elo Trajectory: {top_agent}', fontsize=14, fontweight='bold')\n",
+    "ax.legend()\n",
+    "ax.grid(True, alpha=0.3)\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Late-Entering Agents\n",
+    "\n",
+    "Agents that enter the tournament late start at the default rating. Let's check if any agents have shorter trajectories."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Find agents with different trajectory lengths\n",
+    "traj_lengths = [(agent, len(traj.ratings)) for agent, traj in history_filtered.trajectories.items()]\n",
+    "traj_lengths.sort(key=lambda x: x[1])\n",
+    "\n",
+    "print(\"Trajectory lengths (number of snapshots):\")\n",
+    "for agent, length in traj_lengths:\n",
+    "    final = history_filtered.trajectories[agent].final_rating\n",
+    "    print(f\"  {agent}: {length} snapshots, final rating: {final:.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Custom Parameters\n",
+    "\n",
+    "Let's experiment with different K-factors to see how they affect rating volatility."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Compare different K-factors\n",
+    "fig, axes = plt.subplots(1, 3, figsize=(15, 5))\n",
+    "\n",
+    "k_values = [16, 32, 64]\n",
+    "\n",
+    "for ax, k in zip(axes, k_values):\n",
+    "    history_k = compute_elo_trajectories(\n",
+    "        all_results[:100] if len(all_results) > 100 else all_results,  # Limit for speed\n",
+    "        k=k,\n",
+    "        start_rating=DEFAULT_RATING,\n",
+    "        game_filter=game_filter,\n",
+    "    )\n",
+    "    \n",
+    "    for agent, traj in sorted(history_k.trajectories.items()):\n",
+    "        ax.plot(traj.ratings, alpha=0.7, linewidth=1.5)\n",
+    "    \n",
+    "    ax.set_xlabel('Match Number')\n",
+    "    ax.set_ylabel('Elo Rating')\n",
+    "    ax.set_title(f'K = {k}')\n",
+    "    ax.grid(True, alpha=0.3)\n",
+    "\n",
+    "plt.suptitle('Effect of K-Factor on Rating Volatility', fontsize=14, fontweight='bold')\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Save Results\n",
+    "\n",
+    "Export the trajectory data for further analysis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Save trajectory CSV\n",
+    "csv_path = output_dir / \"elo_over_time_notebook.csv\"\n",
+    "save_trajectory_csv(history_filtered, csv_path)\n",
+    "\n",
+    "# Load and display as DataFrame\n",
+    "df = pd.read_csv(csv_path)\n",
+    "df.head(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pivot to wide format for easy viewing\n",
+    "wide_df = df.pivot(index='match_index', columns='agent', values='elo_rating')\n",
+    "wide_df.head(10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Conclusions\n",
+    "\n",
+    "The Elo over time visualization reveals several insights:\n",
+    "\n",
+    "1. **Rating convergence**: Over time, ratings tend to stabilize as agents find their true skill level\n",
+    "2. **K-factor impact**: Higher K-factors lead to more volatile ratings (bigger swings per match)\n",
+    "3. **Late entry**: Agents entering mid-tournament start at the default rating and may take time to reach their true level\n",
+    "4. **Agent comparison**: The chart makes it easy to compare agent performance over time\n",
+    "\n",
+    "### Key Observations\n",
+    "\n",
+    "- Search-based agents (MCTS variants) typically show steady, predictable rating trajectories\n",
+    "- LLM-based agents may show more variance depending on their consistency\n",
+    "- The random agent serves as a baseline - ratings below the starting value indicate weakness\n",
+    "\n",
+    "### Next Steps\n",
+    "\n",
+    "- Use the CLI script for batch processing: `python3 scripts/plot_elo_over_time.py results/*.csv`\n",
+    "- Compare with static Elo leaderboards for final rankings\n",
+    "- Combine with matchup heatmaps to understand pairwise dynamics"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/scripts/plot_elo_over_time.py
+++ b/scripts/plot_elo_over_time.py
@@ -1,0 +1,704 @@
+#!/usr/bin/env python3
+"""
+scripts.plot_elo_over_time — Elo Rating Evolution Visualization
+================================================================
+Generates a line chart showing how agent Elo ratings evolve over the course
+of a tournament.
+
+Features:
+- Reads results from CSV files (canonical arena format)
+- Computes Elo trajectories incrementally after each match
+- Supports game and agent filtering
+- Color scheme: search-based agents (random, mcts-*) in blue/grey tones;
+  LLM-based agents (llm-*) in warm tones (orange/red/yellow)
+- Outputs PNG chart and CSV of trajectories
+
+CLI Usage:
+    python3 scripts/plot_elo_over_time.py results/*.csv
+    python3 scripts/plot_elo_over_time.py results/*.csv --output-dir output/
+    python3 scripts/plot_elo_over_time.py results/*.csv --game breakthrough
+    python3 scripts/plot_elo_over_time.py results/*.csv --agents mcts-500,random
+    python3 scripts/plot_elo_over_time.py results/*.csv --k 20 --start 1000
+
+References
+----------
+- Elo, A. E. (1978). *The Rating of Chessplayers, Past and Present*.
+- https://en.wikipedia.org/wiki/Elo_rating_system
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Default constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_RATING: float = 1500.0
+K_FACTOR: float = 32.0
+
+
+# ---------------------------------------------------------------------------
+# Data structures for Elo trajectories
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class EloTrajectory:
+    """Elo rating history for a single agent over the course of a tournament.
+
+    Attributes
+    ----------
+    agent:
+        Agent name.
+    ratings:
+        List of Elo ratings, one per match index (0 = initial rating).
+    """
+
+    agent: str
+    ratings: list[float] = field(default_factory=list)
+    start_rating: float = DEFAULT_RATING
+
+    def record(self, rating: float) -> None:
+        """Append a rating snapshot."""
+        self.ratings.append(rating)
+
+    @property
+    def final_rating(self) -> float:
+        """Return the final (most recent) rating."""
+        return self.ratings[-1] if self.ratings else self.start_rating
+
+
+@dataclass
+class EloHistory:
+    """Complete Elo history for all agents across a tournament.
+
+    Attributes
+    ----------
+    trajectories:
+        Dict mapping agent name to its EloTrajectory.
+    game:
+        Name of the game (if filtered).
+    total_matches:
+        Total number of matches processed.
+    """
+
+    trajectories: dict[str, EloTrajectory] = field(default_factory=dict)
+    game: str = ""
+    total_matches: int = 0
+    start_rating: float = DEFAULT_RATING
+
+    def get_trajectory(self, agent: str) -> EloTrajectory:
+        """Get or create a trajectory for an agent."""
+        if agent not in self.trajectories:
+            self.trajectories[agent] = EloTrajectory(
+                agent=agent, start_rating=self.start_rating
+            )
+        return self.trajectories[agent]
+
+    def to_csv_rows(self) -> list[dict[str, Any]]:
+        """Convert to flat list of rows for CSV export.
+
+        Returns
+        -------
+        list[dict]
+            Each row has: match_index, agent, elo_rating
+        """
+        rows = []
+        for agent, traj in sorted(self.trajectories.items()):
+            for match_idx, rating in enumerate(traj.ratings):
+                rows.append(
+                    {
+                        "match_index": match_idx,
+                        "agent": agent,
+                        "elo_rating": round(rating, 2),
+                    }
+                )
+        return rows
+
+
+# ---------------------------------------------------------------------------
+# Elo computation
+# ---------------------------------------------------------------------------
+
+
+def expected_score(rating_a: float, rating_b: float) -> float:
+    """Return the expected score for player A against player B.
+
+    The score is a probability in [0, 1] where 1 means certain win.
+
+    Parameters
+    ----------
+    rating_a:
+        Current Elo rating of player A.
+    rating_b:
+        Current Elo rating of player B.
+    """
+    return 1.0 / (1.0 + 10.0 ** ((rating_b - rating_a) / 400.0))
+
+
+def compute_elo_trajectories(
+    results: list[dict[str, Any]],
+    k: float = K_FACTOR,
+    start_rating: float = DEFAULT_RATING,
+    game_filter: str | None = None,
+    agent_filter: set[str] | None = None,
+) -> EloHistory:
+    """Compute Elo trajectories from match results.
+
+    Processes matches in order, updating ratings after each game and
+    recording a snapshot for all known agents.
+
+    Parameters
+    ----------
+    results:
+        List of row dictionaries from CSV files.
+    k:
+        K-factor controlling how much each result shifts ratings.
+    start_rating:
+        Starting rating for new agents.
+    game_filter:
+        If provided, only include results for this game.
+    agent_filter:
+        If provided, only track these agents. Matches involving other
+        agents are still processed for Elo updates, but those agents
+        are not included in the output trajectories.
+
+    Returns
+    -------
+    EloHistory
+        Complete history with trajectories for each agent.
+    """
+    history = EloHistory(start_rating=start_rating)
+    current_ratings: dict[str, float] = {}
+
+    def _get_rating(name: str) -> float:
+        """Get current rating, initializing new agents at start_rating."""
+        return current_ratings.setdefault(name, start_rating)
+
+    # Track which agents we've seen (for initial snapshot)
+    agents_seen: set[str] = set()
+
+    match_idx = 0
+    for row in results:
+        # Apply game filter
+        if game_filter:
+            row_game = row.get("game", "")
+            if row_game != game_filter:
+                continue
+
+        agent_a = row.get("agent_a", "")
+        agent_b = row.get("agent_b", "")
+
+        if not agent_a or not agent_b:
+            continue
+
+        # Determine outcome from winner field
+        winner_raw = row.get("winner", "")
+        is_draw = row.get("is_draw", "").lower() == "true" or winner_raw == ""
+
+        if is_draw:
+            outcome = "draw"
+        elif winner_raw == agent_a:
+            outcome = "win"
+        else:
+            outcome = "loss"
+
+        # Get current ratings (initialize if first time seen)
+        ra = _get_rating(agent_a)
+        rb = _get_rating(agent_b)
+
+        # Record initial ratings for new agents before the match
+        for agent in [agent_a, agent_b]:
+            if agent not in agents_seen:
+                agents_seen.add(agent)
+                traj = history.get_trajectory(agent)
+                traj.record(current_ratings[agent])
+
+        # Compute expected scores
+        ea = expected_score(ra, rb)
+        eb = expected_score(rb, ra)
+
+        # Determine actual scores
+        if outcome == "win":
+            sa, sb = 1.0, 0.0
+        elif outcome == "loss":
+            sa, sb = 0.0, 1.0
+        else:  # draw
+            sa, sb = 0.5, 0.5
+
+        # Update ratings
+        current_ratings[agent_a] = ra + k * (sa - ea)
+        current_ratings[agent_b] = rb + k * (sb - eb)
+
+        match_idx += 1
+
+        # Record post-match ratings for all seen agents
+        for agent in agents_seen:
+            traj = history.get_trajectory(agent)
+            traj.record(current_ratings.get(agent, start_rating))
+
+    # Apply agent filter if provided
+    if agent_filter:
+        filtered_trajectories = {
+            agent: traj
+            for agent, traj in history.trajectories.items()
+            if agent in agent_filter
+        }
+        history.trajectories = filtered_trajectories
+
+    # Set metadata
+    history.total_matches = match_idx
+    if results and not game_filter:
+        history.game = results[0].get("game", "")
+
+    return history
+
+
+# ---------------------------------------------------------------------------
+# CSV Loading
+# ---------------------------------------------------------------------------
+
+
+def load_results_from_csv(path: str | Path) -> list[dict[str, Any]]:
+    """Load results from a CSV file in canonical arena format.
+
+    Parameters
+    ----------
+    path:
+        Path to the CSV file.
+
+    Returns
+    -------
+    list[dict]
+        List of row dictionaries with canonical column names.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Results file not found: {path}")
+
+    with open(path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        return list(reader)
+
+
+def load_all_results(*csv_paths: str | Path) -> list[dict[str, Any]]:
+    """Load and concatenate results from multiple CSV files.
+
+    Parameters
+    ----------
+    *csv_paths:
+        One or more paths to CSV files.
+
+    Returns
+    -------
+    list[dict]
+        Combined list of all rows.
+    """
+    all_results: list[dict[str, Any]] = []
+    for path in csv_paths:
+        all_results.extend(load_results_from_csv(path))
+    return all_results
+
+
+# ---------------------------------------------------------------------------
+# Color assignment
+# ---------------------------------------------------------------------------
+
+
+def get_agent_color(agent: str, agents: list[str]) -> tuple[float, float, float, float]:
+    """Assign a color to an agent based on its type.
+
+    Color scheme:
+    - Search-based agents (random, mcts-*): blue/grey tones
+    - LLM-based agents (llm-*): warm tones (orange/red/yellow)
+
+    Parameters
+    ----------
+    agent:
+        Agent name.
+    agents:
+        Sorted list of all agents (for consistent color assignment).
+
+    Returns
+    -------
+    tuple
+        RGBA color tuple.
+    """
+    # Determine agent type
+    is_llm = agent.startswith("llm-") or "gpt" in agent.lower() or "claude" in agent.lower()
+    is_search = agent.startswith("mcts") or agent == "random" or agent.startswith("mcts-")
+
+    # Sort agents within each category for consistent colors
+    llm_agents = sorted([a for a in agents if a.startswith("llm-") or "gpt" in a.lower() or "claude" in a.lower()])
+    search_agents = sorted([a for a in agents if a.startswith("mcts") or a == "random" or a.startswith("mcts-")])
+    other_agents = sorted([a for a in agents if a not in llm_agents and a not in search_agents])
+
+    if is_llm:
+        # Warm tones: orange, red, yellow, coral, gold
+        warm_colors = [
+            (1.0, 0.6, 0.2, 1.0),    # Orange
+            (0.9, 0.3, 0.24, 1.0),   # Red
+            (0.96, 0.87, 0.3, 1.0),  # Yellow/Gold
+            (1.0, 0.5, 0.31, 1.0),   # Coral
+            (0.85, 0.45, 0.2, 1.0),  # Burnt orange
+            (0.93, 0.4, 0.36, 1.0),  # Tomato
+            (1.0, 0.75, 0.0, 1.0),   # Amber
+            (0.8, 0.3, 0.3, 1.0),    # Indian red
+        ]
+        idx = llm_agents.index(agent) % len(warm_colors)
+        return warm_colors[idx]
+
+    elif is_search:
+        # Cool tones: blue, grey, teal
+        cool_colors = [
+            (0.2, 0.4, 0.8, 1.0),    # Blue
+            (0.5, 0.5, 0.55, 1.0),   # Grey
+            (0.25, 0.55, 0.65, 1.0), # Teal
+            (0.3, 0.45, 0.7, 1.0),   # Steel blue
+            (0.15, 0.35, 0.6, 1.0),  # Navy
+            (0.4, 0.6, 0.8, 1.0),    # Sky blue
+            (0.45, 0.45, 0.5, 1.0),  # Dim grey
+            (0.2, 0.5, 0.6, 1.0),    # Dark cyan
+        ]
+        idx = search_agents.index(agent) % len(cool_colors)
+        return cool_colors[idx]
+
+    else:
+        # Other agents: green/purple tones
+        other_colors = [
+            (0.3, 0.7, 0.4, 1.0),    # Green
+            (0.6, 0.4, 0.7, 1.0),    # Purple
+            (0.4, 0.75, 0.55, 1.0),  # Sea green
+            (0.7, 0.5, 0.8, 1.0),    # Lavender
+            (0.2, 0.6, 0.35, 1.0),   # Forest green
+        ]
+        idx = other_agents.index(agent) % len(other_colors)
+        return other_colors[idx]
+
+
+# ---------------------------------------------------------------------------
+# Plotting
+# ---------------------------------------------------------------------------
+
+
+def plot_elo_over_time(
+    history: EloHistory,
+    output_path: str | Path,
+    title: str | None = None,
+    figsize: tuple[int, int] = (12, 7),
+    dpi: int = 150,
+) -> None:
+    """Plot Elo trajectories and save to file.
+
+    Parameters
+    ----------
+    history:
+        EloHistory with trajectories for each agent.
+    output_path:
+        Path to save the PNG file.
+    title:
+        Custom title for the plot.
+    figsize:
+        Figure size as (width, height).
+    dpi:
+        Resolution for the output image.
+    """
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError as exc:
+        raise ImportError(
+            "matplotlib is required for plotting. "
+            "Install it with: pip install -e '.[analysis]'"
+        ) from exc
+
+    if not history.trajectories:
+        print("No agent trajectories to plot.")
+        return
+
+    # Get sorted list of agents
+    sorted_agents = sorted(history.trajectories.keys())
+    n_agents = len(sorted_agents)
+
+    # Create figure with appropriate size for slide resolution
+    fig, ax = plt.subplots(figsize=figsize)
+
+    # Plot each agent's trajectory
+    for agent in sorted_agents:
+        traj = history.trajectories[agent]
+        if not traj.ratings:
+            continue
+
+        color = get_agent_color(agent, sorted_agents)
+        ax.plot(
+            range(len(traj.ratings)),
+            traj.ratings,
+            label=agent,
+            color=color,
+            linewidth=2,
+            alpha=0.85,
+        )
+
+    # Set labels and title
+    ax.set_xlabel("Match Number", fontsize=14, fontweight="bold")
+    ax.set_ylabel("Elo Rating", fontsize=14, fontweight="bold")
+
+    if title is None:
+        game_name = history.game or "Tournament"
+        title = f"Elo Rating Evolution — {game_name}"
+    ax.set_title(title, fontsize=16, fontweight="bold", pad=15)
+
+    # Configure legend
+    # Place legend outside plot if many agents
+    if n_agents > 6:
+        ax.legend(
+            loc="upper left",
+            bbox_to_anchor=(1.02, 1),
+            fontsize=11,
+            framealpha=0.95,
+        )
+        plt.tight_layout(rect=[0, 0, 0.85, 1])
+    else:
+        ax.legend(loc="best", fontsize=11, framealpha=0.95)
+        plt.tight_layout()
+
+    # Grid
+    ax.grid(True, alpha=0.3, linestyle="--")
+
+    # Ensure x-axis starts at 0
+    ax.set_xlim(left=0)
+
+    # Make tick labels readable
+    ax.tick_params(axis="both", labelsize=11)
+
+    # Save figure
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(output_path, dpi=dpi, bbox_inches="tight", facecolor="white")
+    plt.close(fig)
+
+    print(f"Saved Elo chart to {output_path}")
+
+
+def save_trajectory_csv(
+    history: EloHistory,
+    output_path: str | Path,
+) -> None:
+    """Save Elo trajectories to a CSV file.
+
+    Parameters
+    ----------
+    history:
+        EloHistory with trajectories for each agent.
+    output_path:
+        Path to save the CSV file.
+    """
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    rows = history.to_csv_rows()
+
+    with open(output_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["match_index", "agent", "elo_rating"])
+        writer.writeheader()
+        writer.writerows(rows)
+
+    print(f"Saved Elo trajectory CSV to {output_path}")
+
+
+# ---------------------------------------------------------------------------
+# CLI utilities
+# ---------------------------------------------------------------------------
+
+
+def expand_glob_paths(patterns: list[str]) -> list[str]:
+    """Expand glob patterns to actual file paths.
+
+    Parameters
+    ----------
+    patterns:
+        List of file paths or glob patterns.
+
+    Returns
+    -------
+    list[str]
+        Expanded list of file paths.
+    """
+    from glob import glob
+
+    expanded: list[str] = []
+    for pattern in patterns:
+        # Check if it's a glob pattern
+        if "*" in pattern or "?" in pattern:
+            matches = sorted(glob(pattern))
+            expanded.extend(matches)
+        else:
+            expanded.append(pattern)
+
+    return expanded
+
+
+# ---------------------------------------------------------------------------
+# CLI Entry Point
+# ---------------------------------------------------------------------------
+
+
+def main(args: list[str] | None = None) -> int:
+    """CLI entry point for plotting Elo over time.
+
+    Usage:
+        python3 scripts/plot_elo_over_time.py results/*.csv
+        python3 scripts/plot_elo_over_time.py results/*.csv --output-dir output/
+        python3 scripts/plot_elo_over_time.py results/*.csv --game breakthrough
+        python3 scripts/plot_elo_over_time.py results/*.csv --agents mcts-500,random
+        python3 scripts/plot_elo_over_time.py results/*.csv --k 20 --start 1000
+
+    Parameters
+    ----------
+    args:
+        Command line arguments (defaults to sys.argv[1:]).
+
+    Returns
+    -------
+    int
+        Exit code (0 for success, 1 for error).
+    """
+    parser = argparse.ArgumentParser(
+        description="Generate Elo rating evolution chart from match results",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python3 scripts/plot_elo_over_time.py results/*.csv
+  python3 scripts/plot_elo_over_time.py results/*.csv --game breakthrough
+  python3 scripts/plot_elo_over_time.py results/*.csv --agents mcts-500,llm-gpt-4
+  python3 scripts/plot_elo_over_time.py results/*.csv --k 20 --start 1000
+  python3 scripts/plot_elo_over_time.py results/*.csv --output-dir output/
+""",
+    )
+
+    parser.add_argument(
+        "csv_paths",
+        nargs="+",
+        help="One or more CSV file paths (supports glob patterns)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="output/",
+        help="Output directory for PNG and CSV files (default: output/)",
+    )
+    parser.add_argument(
+        "--game",
+        type=str,
+        default=None,
+        help="Filter results to a specific game",
+    )
+    parser.add_argument(
+        "--agents",
+        type=str,
+        default=None,
+        help="Comma-separated list of agents to include (others filtered out)",
+    )
+    parser.add_argument(
+        "--k",
+        type=float,
+        default=K_FACTOR,
+        help=f"Elo K-factor (default: {K_FACTOR})",
+    )
+    parser.add_argument(
+        "--start",
+        type=float,
+        default=DEFAULT_RATING,
+        help=f"Starting Elo rating (default: {DEFAULT_RATING})",
+    )
+
+    parsed = parser.parse_args(args)
+
+    # Expand glob patterns
+    csv_paths = expand_glob_paths(parsed.csv_paths)
+
+    if not csv_paths:
+        print("Error: No CSV files found.", file=sys.stderr)
+        return 1
+
+    # Verify files exist
+    for path in csv_paths:
+        if not Path(path).exists():
+            print(f"Error: File not found: {path}", file=sys.stderr)
+            return 1
+
+    print(f"Processing {len(csv_paths)} CSV file(s)...")
+
+    try:
+        # Load all results
+        all_results = load_all_results(*csv_paths)
+        print(f"Loaded {len(all_results)} match records")
+
+        # Parse agent filter
+        agent_filter = None
+        if parsed.agents:
+            agent_filter = set(a.strip() for a in parsed.agents.split(","))
+
+        # Compute trajectories
+        history = compute_elo_trajectories(
+            all_results,
+            k=parsed.k,
+            start_rating=parsed.start,
+            game_filter=parsed.game,
+            agent_filter=agent_filter,
+        )
+
+        if not history.trajectories:
+            print("Error: No agent trajectories computed.", file=sys.stderr)
+            return 1
+
+        print(f"Computed trajectories for {len(history.trajectories)} agents")
+        print(f"Total matches processed: {history.total_matches}")
+
+        # Show final ratings
+        sorted_agents = sorted(
+            history.trajectories.keys(),
+            key=lambda a: history.trajectories[a].final_rating,
+            reverse=True,
+        )
+        print("\nFinal Elo Ratings:")
+        for agent in sorted_agents:
+            traj = history.trajectories[agent]
+            print(f"  {agent}: {traj.final_rating:.1f}")
+
+        # Create output directory
+        output_dir = Path(parsed.output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        # Generate output filenames
+        game_suffix = f"_{parsed.game}" if parsed.game else ""
+        png_path = output_dir / f"elo_over_time{game_suffix}.png"
+        csv_path = output_dir / f"elo_over_time{game_suffix}.csv"
+
+        # Plot chart
+        plot_elo_over_time(history, output_path=png_path)
+
+        # Save trajectory CSV
+        save_trajectory_csv(history, output_path=csv_path)
+
+        print(f"\nDone! Generated:")
+        print(f"  - {png_path}")
+        print(f"  - {csv_path}")
+
+        return 0
+
+    except Exception as e:
+        print(f"Error processing files: {e}", file=sys.stderr)
+        import traceback
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_elo_over_time.py
+++ b/tests/test_elo_over_time.py
@@ -1,0 +1,514 @@
+"""
+Tests for scripts.plot_elo_over_time — Elo trajectory computation and visualization.
+"""
+
+from __future__ import annotations
+
+import csv
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from scripts.plot_elo_over_time import (
+    DEFAULT_RATING,
+    K_FACTOR,
+    EloHistory,
+    EloTrajectory,
+    compute_elo_trajectories,
+    expected_score,
+    get_agent_color,
+    load_all_results,
+    load_results_from_csv,
+    main,
+    save_trajectory_csv,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def sample_results() -> list[dict[str, str]]:
+    """Return a small list of match result dictionaries."""
+    return [
+        {
+            "run_id": "match1",
+            "game": "tic_tac_toe",
+            "agent_a": "alpha",
+            "agent_b": "beta",
+            "winner": "alpha",
+            "is_draw": "False",
+        },
+        {
+            "run_id": "match2",
+            "game": "tic_tac_toe",
+            "agent_a": "beta",
+            "agent_b": "alpha",
+            "winner": "alpha",
+            "is_draw": "False",
+        },
+        {
+            "run_id": "match3",
+            "game": "tic_tac_toe",
+            "agent_a": "alpha",
+            "agent_b": "beta",
+            "winner": "",
+            "is_draw": "True",
+        },
+    ]
+
+
+@pytest.fixture()
+def sample_csv_file(tmp_path: Path) -> Path:
+    """Create a sample CSV file with match results."""
+    csv_path = tmp_path / "test_results.csv"
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(
+            [
+                "run_id",
+                "game",
+                "agent_a",
+                "agent_b",
+                "winner",
+                "is_draw",
+                "num_moves",
+            ]
+        )
+        # Alpha beats beta
+        writer.writerow(["id1", "tic_tac_toe", "alpha", "beta", "alpha", "False", "5"])
+        # Beta beats gamma
+        writer.writerow(["id2", "tic_tac_toe", "beta", "gamma", "beta", "False", "7"])
+        # Alpha vs gamma draw
+        writer.writerow(["id3", "tic_tac_toe", "alpha", "gamma", "", "True", "9"])
+    return csv_path
+
+
+@pytest.fixture()
+def late_entry_csv_file(tmp_path: Path) -> Path:
+    """Create a CSV file where an agent enters mid-tournament."""
+    csv_path = tmp_path / "late_entry.csv"
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(
+            ["run_id", "game", "agent_a", "agent_b", "winner", "is_draw", "num_moves"]
+        )
+        # First few matches: only alpha and beta
+        writer.writerow(["id1", "test", "alpha", "beta", "alpha", "False", "5"])
+        writer.writerow(["id2", "test", "alpha", "beta", "alpha", "False", "5"])
+        writer.writerow(["id3", "test", "alpha", "beta", "alpha", "False", "5"])
+        # Now gamma enters
+        writer.writerow(["id4", "test", "gamma", "alpha", "alpha", "False", "5"])
+        writer.writerow(["id5", "test", "gamma", "beta", "beta", "False", "5"])
+    return csv_path
+
+
+@pytest.fixture()
+def multi_game_csv_file(tmp_path: Path) -> Path:
+    """Create a CSV file with results from multiple games."""
+    csv_path = tmp_path / "multi_game.csv"
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(
+            ["run_id", "game", "agent_a", "agent_b", "winner", "is_draw", "num_moves"]
+        )
+        writer.writerow(["id1", "game_a", "agent1", "agent2", "agent1", "False", "5"])
+        writer.writerow(["id2", "game_b", "agent1", "agent2", "agent2", "False", "5"])
+        writer.writerow(["id3", "game_a", "agent1", "agent2", "agent1", "False", "5"])
+    return csv_path
+
+
+# ---------------------------------------------------------------------------
+# Basic Elo computation tests
+# ---------------------------------------------------------------------------
+
+
+def test_expected_score_equal_ratings():
+    """Equal ratings should give 50% expected score."""
+    assert expected_score(1500, 1500) == pytest.approx(0.5)
+
+
+def test_expected_score_higher_vs_lower():
+    """Higher rated player should have >50% expected score."""
+    assert expected_score(1600, 1400) > 0.5
+
+
+def test_expected_score_symmetry():
+    """Expected scores should sum to 1."""
+    assert expected_score(1500, 1700) + expected_score(1700, 1500) == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# EloTrajectory tests
+# ---------------------------------------------------------------------------
+
+
+def test_elo_trajectory_record():
+    """Should record rating snapshots correctly."""
+    traj = EloTrajectory(agent="test_agent", start_rating=1500.0)
+    traj.record(1510.0)
+    traj.record(1520.0)
+    traj.record(1505.0)
+
+    assert len(traj.ratings) == 3
+    assert traj.ratings == [1510.0, 1520.0, 1505.0]
+
+
+def test_elo_trajectory_final_rating():
+    """Final rating should return the last recorded value."""
+    traj = EloTrajectory(agent="test_agent", start_rating=1500.0)
+    assert traj.final_rating == 1500.0  # No ratings recorded
+
+    traj.record(1510.0)
+    traj.record(1520.0)
+    assert traj.final_rating == 1520.0
+
+
+# ---------------------------------------------------------------------------
+# EloHistory tests
+# ---------------------------------------------------------------------------
+
+
+def test_elo_history_get_trajectory():
+    """Should create and retrieve trajectories."""
+    history = EloHistory()
+    traj = history.get_trajectory("agent1")
+    assert isinstance(traj, EloTrajectory)
+    assert traj.agent == "agent1"
+
+    # Same agent should return same trajectory
+    traj2 = history.get_trajectory("agent1")
+    assert traj is traj2
+
+
+def test_elo_history_to_csv_rows():
+    """Should convert to flat CSV rows correctly."""
+    history = EloHistory()
+    traj1 = history.get_trajectory("alpha")
+    traj1.record(1500.0)
+    traj1.record(1510.0)
+    traj1.record(1505.0)
+
+    traj2 = history.get_trajectory("beta")
+    traj2.record(1500.0)
+    traj2.record(1490.0)
+    traj2.record(1495.0)
+
+    rows = history.to_csv_rows()
+
+    # Should have 3 rows per agent
+    assert len(rows) == 6
+
+    # Check structure
+    assert all("match_index" in row for row in rows)
+    assert all("agent" in row for row in rows)
+    assert all("elo_rating" in row for row in rows)
+
+
+# ---------------------------------------------------------------------------
+# Trajectory computation tests
+# ---------------------------------------------------------------------------
+
+
+def test_compute_trajectories_basic(sample_results: list[dict[str, str]]):
+    """Should compute trajectories with correct number of snapshots."""
+    history = compute_elo_trajectories(sample_results)
+
+    assert len(history.trajectories) == 2
+    assert "alpha" in history.trajectories
+    assert "beta" in history.trajectories
+    assert history.total_matches == 3
+
+    # Each trajectory should have 4 points: initial + after each of 3 matches
+    alpha_traj = history.trajectories["alpha"]
+    assert len(alpha_traj.ratings) == 4  # 1 initial + 3 updates
+
+
+def test_compute_trajectories_alpha_wins(sample_results: list[dict[str, str]]):
+    """Alpha wins twice and draws once, should have highest final rating."""
+    history = compute_elo_trajectories(sample_results)
+
+    alpha_final = history.trajectories["alpha"].final_rating
+    beta_final = history.trajectories["beta"].final_rating
+
+    assert alpha_final > beta_final
+
+
+def test_compute_trajectories_custom_params(sample_results: list[dict[str, str]]):
+    """Should accept custom K-factor and start rating."""
+    history = compute_elo_trajectories(sample_results, k=50, start_rating=1000)
+
+    # Alpha should still be higher rated
+    alpha_final = history.trajectories["alpha"].final_rating
+    beta_final = history.trajectories["beta"].final_rating
+
+    assert alpha_final > 1000
+    assert beta_final < 1000
+
+
+def test_compute_trajectories_empty_results():
+    """Empty results should give empty history."""
+    history = compute_elo_trajectories([])
+    assert len(history.trajectories) == 0
+    assert history.total_matches == 0
+
+
+def test_compute_trajectories_late_entry_agent(late_entry_csv_file: Path):
+    """Agents entering mid-tournament should initialize at start rating."""
+    results = load_results_from_csv(late_entry_csv_file)
+    history = compute_elo_trajectories(results)
+
+    # All three agents should be present
+    assert "alpha" in history.trajectories
+    assert "beta" in history.trajectories
+    assert "gamma" in history.trajectories
+
+    gamma_traj = history.trajectories["gamma"]
+
+    # Gamma's first rating should be the default start rating
+    assert gamma_traj.ratings[0] == DEFAULT_RATING
+
+    # Gamma's trajectory should be shorter than alpha's (entered later)
+    alpha_traj = history.trajectories["alpha"]
+    assert len(gamma_traj.ratings) < len(alpha_traj.ratings)
+
+
+def test_compute_trajectories_game_filter(multi_game_csv_file: Path):
+    """Game filter should exclude results from other games."""
+    results = load_results_from_csv(multi_game_csv_file)
+
+    # Filter to game_a
+    history_a = compute_elo_trajectories(results, game_filter="game_a")
+    assert history_a.total_matches == 2  # Only 2 game_a matches
+
+    # Filter to game_b
+    history_b = compute_elo_trajectories(results, game_filter="game_b")
+    assert history_b.total_matches == 1  # Only 1 game_b match
+
+
+def test_compute_trajectories_agent_filter(sample_results: list[dict[str, str]]):
+    """Agent filter should only include specified agents."""
+    # Add another agent to the results
+    extended_results = list(sample_results) + [
+        {
+            "run_id": "match4",
+            "game": "tic_tac_toe",
+            "agent_a": "gamma",
+            "agent_b": "delta",
+            "winner": "gamma",
+            "is_draw": "False",
+        }
+    ]
+
+    # Filter to only alpha and beta
+    history = compute_elo_trajectories(
+        extended_results, agent_filter={"alpha", "beta"}
+    )
+
+    assert len(history.trajectories) == 2
+    assert "alpha" in history.trajectories
+    assert "beta" in history.trajectories
+    assert "gamma" not in history.trajectories
+    assert "delta" not in history.trajectories
+
+
+# ---------------------------------------------------------------------------
+# CSV loading tests
+# ---------------------------------------------------------------------------
+
+
+def test_load_results_from_csv(sample_csv_file: Path):
+    """Should load CSV rows correctly."""
+    rows = load_results_from_csv(sample_csv_file)
+    assert len(rows) == 3
+    assert rows[0]["agent_a"] == "alpha"
+    assert rows[0]["winner"] == "alpha"
+
+
+def test_load_results_from_csv_not_found():
+    """Should raise FileNotFoundError for missing file."""
+    with pytest.raises(FileNotFoundError):
+        load_results_from_csv("/nonexistent/path/file.csv")
+
+
+def test_load_all_results(sample_csv_file: Path, tmp_path: Path):
+    """Should concatenate results from multiple files."""
+    # Create second CSV file
+    csv2 = tmp_path / "results2.csv"
+    with open(csv2, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["run_id", "game", "agent_a", "agent_b", "winner", "is_draw"])
+        writer.writerow(["id4", "test", "x", "y", "x", "False"])
+
+    all_results = load_all_results(sample_csv_file, csv2)
+    assert len(all_results) == 4  # 3 from first file + 1 from second
+
+
+# ---------------------------------------------------------------------------
+# Color assignment tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_agent_color_llm():
+    """LLM agents should get warm colors."""
+    agents = ["llm-gpt-4", "llm-claude", "random"]
+    color = get_agent_color("llm-gpt-4", agents)
+    # Warm colors have higher red component
+    assert color[0] > 0.5  # Red channel
+
+
+def test_get_agent_color_search():
+    """Search-based agents should get cool colors."""
+    agents = ["random", "mcts-500", "llm-gpt-4"]
+    color = get_agent_color("mcts-500", agents)
+    # Cool colors have higher blue component relative to red
+    assert color[2] >= color[0]  # Blue >= Red
+
+
+def test_get_agent_color_consistency():
+    """Same agent should always get same color given same agent list."""
+    agents = ["alpha", "beta", "gamma"]
+    color1 = get_agent_color("alpha", agents)
+    color2 = get_agent_color("alpha", agents)
+    assert color1 == color2
+
+
+# ---------------------------------------------------------------------------
+# CSV output tests
+# ---------------------------------------------------------------------------
+
+
+def test_save_trajectory_csv(tmp_path: Path):
+    """Should save trajectory data to CSV correctly."""
+    history = EloHistory()
+    traj = history.get_trajectory("test_agent")
+    traj.record(1500.0)
+    traj.record(1510.0)
+    traj.record(1505.0)
+
+    output_path = tmp_path / "test_output.csv"
+    save_trajectory_csv(history, output_path)
+
+    assert output_path.exists()
+
+    # Read back and verify
+    with open(output_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert len(rows) == 3
+    assert rows[0]["agent"] == "test_agent"
+    assert rows[0]["match_index"] == "0"
+    assert float(rows[0]["elo_rating"]) == 1500.0
+
+
+def test_save_trajectory_csv_format(tmp_path: Path):
+    """CSV should have correct column headers."""
+    history = EloHistory()
+    traj = history.get_trajectory("agent")
+    traj.record(1500.0)
+
+    output_path = tmp_path / "test.csv"
+    save_trajectory_csv(history, output_path)
+
+    with open(output_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        assert set(reader.fieldnames) == {"match_index", "agent", "elo_rating"}
+
+
+# ---------------------------------------------------------------------------
+# CLI tests
+# ---------------------------------------------------------------------------
+
+
+def test_main_help():
+    """Help should print usage and exit with 0."""
+    # argparse calls sys.exit() when --help is passed
+    with pytest.raises(SystemExit) as exc_info:
+        main(["--help"])
+    assert exc_info.value.code == 0
+
+
+def test_main_file_not_found():
+    """Missing file should return 1."""
+    assert main(["/nonexistent/file.csv"]) == 1
+
+
+def test_main_success(sample_csv_file: Path, tmp_path: Path):
+    """Valid file should generate outputs and return 0."""
+    output_dir = tmp_path / "output"
+    result = main([str(sample_csv_file), "--output-dir", str(output_dir)])
+    assert result == 0
+
+    # Check outputs exist
+    assert (output_dir / "elo_over_time.png").exists()
+    assert (output_dir / "elo_over_time.csv").exists()
+
+
+def test_main_game_filter(multi_game_csv_file: Path, tmp_path: Path):
+    """Game filter should work via CLI."""
+    output_dir = tmp_path / "output"
+    result = main(
+        [str(multi_game_csv_file), "--output-dir", str(output_dir), "--game", "game_a"]
+    )
+    assert result == 0
+
+    # Check output has game suffix
+    assert (output_dir / "elo_over_time_game_a.png").exists()
+
+
+def test_main_agent_filter(sample_csv_file: Path, tmp_path: Path):
+    """Agent filter should work via CLI."""
+    output_dir = tmp_path / "output"
+    result = main(
+        [
+            str(sample_csv_file),
+            "--output-dir",
+            str(output_dir),
+            "--agents",
+            "alpha",
+        ]
+    )
+    assert result == 0
+
+    # Check CSV only has alpha
+    csv_path = output_dir / "elo_over_time.csv"
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        agents = {row["agent"] for row in reader}
+    assert agents == {"alpha"}
+
+
+def test_main_custom_k_and_start(sample_csv_file: Path, tmp_path: Path):
+    """Custom K and start rating should affect results."""
+    output_dir = tmp_path / "output"
+    result = main(
+        [
+            str(sample_csv_file),
+            "--output-dir",
+            str(output_dir),
+            "--k",
+            "50",
+            "--start",
+            "1000",
+        ]
+    )
+    assert result == 0
+
+    # Read CSV and verify ratings are around 1000
+    csv_path = output_dir / "elo_over_time.csv"
+    with open(csv_path, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        ratings = [float(row["elo_rating"]) for row in reader]
+
+    # All ratings should be closer to 1000 than 1500
+    assert all(abs(r - 1000) < 200 for r in ratings)
+
+
+def test_main_no_csv_files():
+    """No CSV files should return 1."""
+    result = main(["/nonexistent/*.csv"])
+    assert result == 1


### PR DESCRIPTION
## Summary

Implements GitHub issue #9: visualization of Elo rating evolution over the course of a tournament.

## Changes

### `scripts/plot_elo_over_time.py` — CLI script
- Accepts one or more CSV paths (glob-friendly)
- Supports `--output-dir` (default: `output/`)
- Supports `--game` filter for specific games
- Supports `--agents` filter (comma-separated list)
- Supports `--k` (Elo K-factor, default 32)
- Supports `--start` (starting Elo, default 1500)
- Produces `output/elo_over_time.png` — line chart, one series per agent
- Produces `output/elo_over_time.csv` — columns: match_index, agent, elo_rating
- Color scheme: search-based agents (random, mcts-*) in blue/grey tones; LLM-based agents (llm-*) in warm tones (orange/red/yellow)
- Labels readable at slide resolution (1920x1080)
- Handles agents entering mid-tournament (initializes at start Elo when first seen)

### `analysis/elo_over_time.ipynb` — Jupyter notebook
- Step-by-step walkthrough of loading results and computing trajectories
- Explains chart interpretation and agent color coding
- Shows parameter exploration (K-factor effects)
- Uses same logic as the script (imports from it)

### `tests/test_elo_over_time.py` — Tests
- 29 tests covering:
  - Trajectory computation with synthetic data
  - Late-entering agents initialize correctly
  - CSV output format
  - Game filtering
  - Agent filtering
  - Color assignment
  - CLI functionality

## Testing

```bash
# Run tests
.venv/bin/python -m pytest tests/test_elo_over_time.py -v

# Run against all results
.venv/bin/python scripts/plot_elo_over_time.py results/*.csv
```

All 29 tests pass. Generated outputs:
- `output/elo_over_time.png` (198KB)
- `output/elo_over_time.csv` (268KB)

Closes #9