### PR TITLE
feat: prompt and memory ablation charts (#11)

### DIFF
--- a/agents/llm_agent.py
+++ b/agents/llm_agent.py
@@ -77,6 +77,7 @@ class LLMAgentConfig:
     fallback_mode: FallbackMode | str = FallbackMode.RANDOM
     temperature: float = 0.7
     max_tokens: int = 500
+    reasoning_effort: str | None = None  # 'low', 'medium', 'high' (o-series / gpt-5.x)
     debug_dir: str | Path | None = None
 
     def __post_init__(self) -> None:
@@ -114,6 +115,7 @@ class LLMAgentConfig:
             else self.fallback_mode,
             "temperature": self.temperature,
             "max_tokens": self.max_tokens,
+            "reasoning_effort": self.reasoning_effort,
             "debug_dir": str(self.debug_dir) if self.debug_dir else None,
         }
 
@@ -369,7 +371,7 @@ class LLMAgent(BaseAgent):
             The raw response text.
         """
         try:
-            response = self._client.chat.completions.create(
+            call_kwargs: dict = dict(
                 model=self._config.model,
                 messages=[
                     {
@@ -378,9 +380,14 @@ class LLMAgent(BaseAgent):
                     },
                     {"role": "user", "content": prompt},
                 ],
-                temperature=self._config.temperature,
                 max_tokens=self._config.max_tokens,
             )
+            if self._config.reasoning_effort:
+                call_kwargs["reasoning_effort"] = self._config.reasoning_effort
+                call_kwargs.pop("max_tokens", None)  # no cap: let reasoning finish
+            else:
+                call_kwargs["temperature"] = self._config.temperature
+            response = self._client.chat.completions.create(**call_kwargs)
 
             content = response.choices[0].message.content
             if content is None:

--- a/analysis/llm_ablation.ipynb
+++ b/analysis/llm_ablation.ipynb
@@ -1,0 +1,265 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# LLM Ablation Analysis — Memory Turns & Prompt Style\n",
+    "\n",
+    "This notebook explores how `memory_turns` and `prompt_style` affect LLM agent performance in the openspiel-arena tournament.\n",
+    "\n",
+    "## Ablation Variables\n",
+    "\n",
+    "| Variable | Values tested |\n",
+    "|----------|--------------|\n",
+    "| `memory_turns` | 0, 1 (baseline), 3 |\n",
+    "| `prompt_style` | `board_summary_then_choice` (baseline), `reason_then_choice` |\n",
+    "\n",
+    "All runs use `tic_tac_toe`, 8 rounds per pairing, vs `random` and `mcts-50`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "# Project imports\n",
+    "from scripts.plot_llm_ablation import (\n",
+    "    load_csvs,\n",
+    "    compute_metrics,\n",
+    "    compute_metrics_by_opponent,\n",
+    "    parse_memory_turns,\n",
+    "    parse_prompt_style,\n",
+    ")\n",
+    "\n",
+    "plt.rcParams.update({\"figure.dpi\": 100, \"figure.figsize\": (10, 5)})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Load Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "RESULTS_DIR = Path(\"results\")\n",
+    "df = load_csvs([RESULTS_DIR])\n",
+    "print(f\"Loaded {len(df)} matches from {RESULTS_DIR}\")\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Identify LLM Variants"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Filter to rows where at least one agent is an LLM variant\n",
+    "llm_mask = df[\"agent_a\"].str.startswith(\"llm-\") | df[\"agent_b\"].str.startswith(\"llm-\")\n",
+    "llm_df = df[llm_mask].copy()\n",
+    "print(f\"{len(llm_df)} matches involve LLM agents\")\n",
+    "\n",
+    "# Show unique LLM agents\n",
+    "llm_agents = sorted(\n",
+    "    set(df[\"agent_a\"]).union(df[\"agent_b\"]) - {a for a in set(df[\"agent_a\"]).union(df[\"agent_b\"]) if not a.startswith(\"llm-\")}\n",
+    ")\n",
+    "print(f\"LLM variants: {llm_agents}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Aggregate Metrics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "metrics = compute_metrics(df)\n",
+    "metrics_df = pd.DataFrame([\n",
+    "    {\n",
+    "        \"variant\": m.variant,\n",
+    "        \"memory_turns\": m.memory_turns,\n",
+    "        \"prompt_style\": m.prompt_style,\n",
+    "        \"games\": m.games,\n",
+    "        \"win_rate\": m.win_rate,\n",
+    "        \"avg_invalid_retries\": m.avg_invalid_retries,\n",
+    "        \"avg_latency_ms\": m.avg_latency_ms,\n",
+    "    }\n",
+    "    for m in metrics\n",
+    "])\n",
+    "metrics_df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Win Rate by Memory Turns (All Opponents)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 5))\n",
+    "\n",
+    "mem_groups = metrics_df.groupby(\"memory_turns\")[\"win_rate\"].mean().sort_index()\n",
+    "\n",
+    "ax.bar(mem_groups.index.astype(str), mem_groups.values, color=[\"#e74c3c\", \"#2ecc71\", \"#3498db\"])\n",
+    "ax.set_xlabel(\"Memory Turns\")\n",
+    "ax.set_ylabel(\"Win Rate\")\n",
+    "ax.set_title(\"Average Win Rate by Memory Turns (across all opponents)\")\n",
+    "ax.set_ylim(0, 1)\n",
+    "\n",
+    "for i, (idx, val) in enumerate(mem_groups.items()):\n",
+    "    ax.text(i, val + 0.02, f\"{val:.1%}\", ha=\"center\", fontsize=12)\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Win Rate Grouped by Opponent"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "metrics_by_opp = compute_metrics_by_opponent(df)\n",
+    "\n",
+    "# Build a table: variant × opponent → win_rate\n",
+    "rows = []\n",
+    "for opp, mlist in metrics_by_opp.items():\n",
+    "    for m in mlist:\n",
+    "        rows.append({\"variant\": m.variant, \"opponent\": opp, \"win_rate\": m.win_rate, \"games\": m.games})\n",
+    "\n",
+    "opp_df = pd.DataFrame(rows)\n",
+    "pivot = opp_df.pivot_table(index=\"variant\", columns=\"opponent\", values=\"win_rate\")\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(12, 5))\n",
+    "pivot.plot(kind=\"bar\", ax=ax, width=0.7)\n",
+    "ax.set_ylabel(\"Win Rate\")\n",
+    "ax.set_title(\"Win Rate by Variant and Opponent\")\n",
+    "ax.set_ylim(0, 1.05)\n",
+    "ax.legend(title=\"Opponent\")\n",
+    "ax.yaxis.set_major_formatter(plt.FuncFormatter(lambda v, _: f\"{v:.0%}\"))\n",
+    "plt.xticks(rotation=30, ha=\"right\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Invalid Move Retry Rate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 5))\n",
+    "\n",
+    "ax.bar(metrics_df[\"variant\"], metrics_df[\"avg_invalid_retries\"], color=\"#e67e22\")\n",
+    "ax.set_xlabel(\"LLM Variant\")\n",
+    "ax.set_ylabel(\"Avg Invalid Retries\")\n",
+    "ax.set_title(\"Invalid Move Retry Rate by Variant\")\n",
+    "plt.xticks(rotation=30, ha=\"right\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Latency by Variant"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 5))\n",
+    "\n",
+    "ax.bar(metrics_df[\"variant\"], metrics_df[\"avg_latency_ms\"], color=\"#3498db\")\n",
+    "ax.set_xlabel(\"LLM Variant\")\n",
+    "ax.set_ylabel(\"Avg Latency (ms)\")\n",
+    "ax.set_title(\"Average Latency by Variant\")\n",
+    "plt.xticks(rotation=30, ha=\"right\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Key Findings\n",
+    "\n",
+    "Summarise the ablation results here after running the tournaments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print summary table\n",
+    "print(metrics_df.to_string(index=False))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/scripts/plot_llm_ablation.py
+++ b/scripts/plot_llm_ablation.py
@@ -1,0 +1,593 @@
+"""
+scripts.plot_llm_ablation — ablation charts for memory_turns and prompt_style
+==============================================================================
+Reads results CSV files from the arena, filters to LLM agent variants, and
+produces charts comparing win-rate, invalid-move rate, and latency across
+memory-turn and prompt-style ablations.
+
+Usage
+-----
+::
+
+    python scripts/plot_llm_ablation.py results/*.csv
+    python scripts/plot_llm_ablation.py results/ --output-dir output/
+
+Deliverables
+------------
+- output/llm_ablation_winrate.png
+- output/llm_ablation_invalid_rate.png
+- output/llm_ablation_latency.png
+- output/llm_ablation_metrics.csv
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+import click
+import pandas as pd
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class VariantMetrics:
+    """Aggregated metrics for a single LLM variant.
+
+    Attributes
+    ----------
+    variant:
+        Agent name (e.g. ``"llm-gpt-5.4-mini-mem0"``).
+    memory_turns:
+        Parsed memory_turns value from the agent name.
+    prompt_style:
+        Parsed prompt_style string (or ``"unknown"``).
+    games:
+        Number of games this agent played.
+    win_rate:
+        Fraction of games won (draws count as 0.5).
+    avg_invalid_retries:
+        Mean ``invalid_move_retries`` across all games.
+    avg_latency_ms:
+        Mean latency in milliseconds for this agent across all games.
+    """
+
+    variant: str
+    memory_turns: int
+    prompt_style: str
+    games: int
+    win_rate: float
+    avg_invalid_retries: float
+    avg_latency_ms: float
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+# Pattern to extract memory_turns from agent name like "llm-gpt-5.4-mini-mem3"
+_MEM_RE = re.compile(r"-mem(\d+)(?:-|$)")
+
+
+def parse_memory_turns(agent_name: str) -> int:
+    """Extract memory_turns integer from an LLM agent name.
+
+    Falls back to 1 if no ``-memN`` token is found.
+
+    Parameters
+    ----------
+    agent_name:
+        The agent name string.
+
+    Returns
+    -------
+    int
+        Parsed memory_turns value.
+    """
+    m = _MEM_RE.search(agent_name)
+    return int(m.group(1)) if m else 1
+
+
+def parse_prompt_style(agent_name: str) -> str:
+    """Best-effort extraction of prompt style from the agent name.
+
+    Since the current naming convention doesn't encode prompt_style, this
+    returns ``"unknown"`` unless the name contains a recognisable token.
+
+    Parameters
+    ----------
+    agent_name:
+        The agent name string.
+
+    Returns
+    -------
+    str
+        A prompt style label.
+    """
+    for style in (
+        "zero_shot",
+        "legal_moves_only",
+        "board_summary_then_choice",
+        "reason_then_choice",
+        "critic_then_choice",
+    ):
+        if style in agent_name:
+            return style
+    return "board_summary_then_choice"
+
+
+def is_llm_agent(name: str) -> bool:
+    """Return ``True`` if *name* looks like an LLM agent variant.
+
+    Parameters
+    ----------
+    name:
+        Agent name string.
+
+    Returns
+    -------
+    bool
+    """
+    return name.startswith("llm-")
+
+
+def _is_llm_variant(name: str) -> bool:
+    """Check if agent name indicates an LLM variant (including prompt-style markers)."""
+    return name.startswith("llm-")
+
+
+# ---------------------------------------------------------------------------
+# CSV loading
+# ---------------------------------------------------------------------------
+
+
+def load_csvs(paths: Sequence[str | Path]) -> pd.DataFrame:
+    """Load and concatenate one or more result CSV files.
+
+    Parameters
+    ----------
+    paths:
+        File paths or glob patterns.
+
+    Returns
+    -------
+    pd.DataFrame
+        Concatenated DataFrame with standardised columns.
+
+    Raises
+    ------
+    FileNotFoundError
+        If none of the paths resolve to existing files.
+    """
+    frames: list[pd.DataFrame] = []
+    for p in paths:
+        path = Path(p)
+        if path.is_dir():
+            frames.extend(_load_dir(path))
+        elif path.is_file():
+            frames.append(pd.read_csv(path))
+        else:
+            # Try glob
+            parent = path.parent
+            pattern = path.name
+            matched = sorted(parent.glob(pattern))
+            if not matched:
+                raise FileNotFoundError(f"No files match: {p}")
+            for f in matched:
+                frames.append(pd.read_csv(f))
+
+    if not frames:
+        raise FileNotFoundError("No CSV files found")
+
+    return pd.concat(frames, ignore_index=True)
+
+
+def _load_dir(directory: Path) -> list[pd.DataFrame]:
+    """Load all ``results_*.csv`` files in *directory*."""
+    frames: list[pd.DataFrame] = []
+    for csv_file in sorted(directory.glob("results_*.csv")):
+        frames.append(pd.read_csv(csv_file))
+    return frames
+
+
+# ---------------------------------------------------------------------------
+# Metric computation
+# ---------------------------------------------------------------------------
+
+
+def compute_metrics(df: pd.DataFrame) -> list[VariantMetrics]:
+    """Compute per-variant ablation metrics from a results DataFrame.
+
+    Each LLM agent variant is identified by its ``agent_a`` / ``agent_b``
+    name.  The function looks at every row where the LLM agent participated
+    (as either side) and aggregates wins, invalid retries, and latency.
+
+    Parameters
+    ----------
+    df:
+        Results DataFrame with at least the columns: ``agent_a``, ``agent_b``,
+        ``winner``, ``is_draw``, ``invalid_move_retries``,
+        ``agent_a_latency_ms``, ``agent_b_latency_ms``.
+
+    Returns
+    -------
+    list[VariantMetrics]
+        One entry per unique LLM agent variant, sorted by variant name.
+    """
+    # Collect all LLM agent names
+    all_agents: set[str] = set()
+    for col in ("agent_a", "agent_b"):
+        for val in df[col].unique():
+            if _is_llm_variant(str(val)):
+                all_agents.add(str(val))
+
+    metrics: list[VariantMetrics] = []
+
+    for agent in sorted(all_agents):
+        wins = 0
+        games = 0
+        invalid_retries: list[float] = []
+        latencies: list[float] = []
+
+        for _, row in df.iterrows():
+            a = str(row["agent_a"])
+            b = str(row["agent_b"])
+            winner = str(row.get("winner", ""))
+            is_draw = str(row.get("is_draw", "False")).lower() == "true"
+
+            if a == agent:
+                games += 1
+                # Win from agent_a perspective
+                if winner == agent:
+                    wins += 1
+                elif is_draw:
+                    wins += 0.5
+                invalid_retries.append(float(row.get("invalid_move_retries", 0)))
+                lat = row.get("agent_a_latency_ms")
+                if lat is not None and not pd.isna(lat):
+                    latencies.append(float(lat))
+
+            elif b == agent:
+                games += 1
+                # Win from agent_b perspective
+                if winner == agent:
+                    wins += 1
+                elif is_draw:
+                    wins += 0.5
+                invalid_retries.append(float(row.get("invalid_move_retries", 0)))
+                lat = row.get("agent_b_latency_ms")
+                if lat is not None and not pd.isna(lat):
+                    latencies.append(float(lat))
+
+        win_rate = wins / games if games > 0 else 0.0
+        avg_invalid = sum(invalid_retries) / len(invalid_retries) if invalid_retries else 0.0
+        avg_latency = sum(latencies) / len(latencies) if latencies else 0.0
+
+        metrics.append(
+            VariantMetrics(
+                variant=agent,
+                memory_turns=parse_memory_turns(agent),
+                prompt_style=parse_prompt_style(agent),
+                games=games,
+                win_rate=win_rate,
+                avg_invalid_retries=avg_invalid,
+                avg_latency_ms=avg_latency,
+            )
+        )
+
+    return metrics
+
+
+def compute_metrics_by_opponent(
+    df: pd.DataFrame,
+) -> dict[str, list[VariantMetrics]]:
+    """Compute per-variant metrics grouped by opponent type.
+
+    Parameters
+    ----------
+    df:
+        Results DataFrame.
+
+    Returns
+    -------
+    dict[str, list[VariantMetrics]]
+        Mapping from opponent name to list of variant metrics.
+    """
+    opponents: set[str] = set()
+    for col in ("agent_a", "agent_b"):
+        for val in df[col].unique():
+            v = str(val)
+            if not _is_llm_variant(v):
+                opponents.add(v)
+
+    result: dict[str, list[VariantMetrics]] = {}
+    for opp in sorted(opponents):
+        mask = (df["agent_a"] == opp) | (df["agent_b"] == opp)
+        subset = df.loc[mask]
+        if len(subset) > 0:
+            result[opp] = compute_metrics(subset)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Plotting
+# ---------------------------------------------------------------------------
+
+
+def _ensure_matplotlib() -> None:
+    """Import matplotlib; raise with a helpful message if missing."""
+    try:
+        import matplotlib  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "matplotlib is required for plots. "
+            "Install it with: pip install -e '.[analysis]'"
+        ) from exc
+
+
+def plot_winrate_chart(
+    metrics_by_opp: dict[str, list[VariantMetrics]],
+    output: Path,
+) -> None:
+    """Produce a grouped bar chart of win-rate by memory_turns, grouped by opponent.
+
+    Parameters
+    ----------
+    metrics_by_opp:
+        Per-opponent variant metrics.
+    output:
+        Path to write the PNG file.
+    """
+    _ensure_matplotlib()
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    # Collect unique variants across all opponents
+    all_variants: list[str] = []
+    seen: set[str] = set()
+    for _, mlist in metrics_by_opp.items():
+        for m in mlist:
+            if m.variant not in seen:
+                all_variants.append(m.variant)
+                seen.add(m.variant)
+
+    if not all_variants:
+        return
+
+    opponents = sorted(metrics_by_opp.keys())
+    n_variants = len(all_variants)
+    n_opponents = len(opponents)
+
+    fig, ax = plt.subplots(figsize=(19.2, 10.8), dpi=100)
+
+    x = np.arange(n_variants)
+    width = 0.8 / max(n_opponents, 1)
+    colours = plt.cm.Set2(np.linspace(0, 1, max(n_opponents, 1)))
+
+    for i, opp in enumerate(opponents):
+        opp_metrics = {m.variant: m for m in metrics_by_opp[opp]}
+        rates = [opp_metrics[v].win_rate if v in opp_metrics else 0.0 for v in all_variants]
+        offset = (i - n_opponents / 2 + 0.5) * width
+        bars = ax.bar(x + offset, rates, width, label=opp, color=colours[i])
+        for bar, rate in zip(bars, rates):
+            ax.text(
+                bar.get_x() + bar.get_width() / 2,
+                bar.get_height() + 0.01,
+                f"{rate:.0%}",
+                ha="center",
+                va="bottom",
+                fontsize=8,
+            )
+
+    ax.set_xlabel("LLM Variant")
+    ax.set_ylabel("Win Rate")
+    ax.set_title("LLM Ablation: Win Rate by Variant and Opponent")
+    ax.set_xticks(x)
+    ax.set_xticklabels(all_variants, rotation=30, ha="right")
+    ax.set_ylim(0, 1.05)
+    ax.legend(title="Opponent")
+    ax.yaxis.set_major_formatter(plt.FuncFormatter(lambda v, _: f"{v:.0%}"))
+    fig.tight_layout()
+    fig.savefig(output, dpi=100)
+    plt.close(fig)
+
+
+def plot_invalid_rate_chart(
+    all_metrics: list[VariantMetrics],
+    output: Path,
+) -> None:
+    """Produce a bar chart of average invalid-move retry rate by variant.
+
+    Parameters
+    ----------
+    all_metrics:
+        List of variant metrics (aggregated across all opponents).
+    output:
+        Path to write the PNG file.
+    """
+    _ensure_matplotlib()
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    variants = [m.variant for m in all_metrics]
+    rates = [m.avg_invalid_retries for m in all_metrics]
+
+    fig, ax = plt.subplots(figsize=(19.2, 10.8), dpi=100)
+
+    x = np.arange(len(variants))
+    bars = ax.bar(x, rates, color=plt.cm.Oranges(np.linspace(0.3, 0.8, len(variants))))
+
+    for bar, rate in zip(bars, rates):
+        ax.text(
+            bar.get_x() + bar.get_width() / 2,
+            bar.get_height() + max(rates) * 0.02 if rates else 0,
+            f"{rate:.2f}",
+            ha="center",
+            va="bottom",
+            fontsize=9,
+        )
+
+    ax.set_xlabel("LLM Variant")
+    ax.set_ylabel("Avg Invalid Move Retries")
+    ax.set_title("LLM Ablation: Invalid Move Retry Rate by Variant")
+    ax.set_xticks(x)
+    ax.set_xticklabels(variants, rotation=30, ha="right")
+    fig.tight_layout()
+    fig.savefig(output, dpi=100)
+    plt.close(fig)
+
+
+def plot_latency_chart(
+    all_metrics: list[VariantMetrics],
+    output: Path,
+) -> None:
+    """Produce a bar chart of average latency (ms) by variant.
+
+    Parameters
+    ----------
+    all_metrics:
+        List of variant metrics (aggregated across all opponents).
+    output:
+        Path to write the PNG file.
+    """
+    _ensure_matplotlib()
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    variants = [m.variant for m in all_metrics]
+    latencies = [m.avg_latency_ms for m in all_metrics]
+
+    fig, ax = plt.subplots(figsize=(19.2, 10.8), dpi=100)
+
+    x = np.arange(len(variants))
+    bars = ax.bar(x, latencies, color=plt.cm.Blues(np.linspace(0.3, 0.8, len(variants))))
+
+    for bar, lat in zip(bars, latencies):
+        ax.text(
+            bar.get_x() + bar.get_width() / 2,
+            bar.get_height() + max(latencies) * 0.02 if latencies else 0,
+            f"{lat:.0f}",
+            ha="center",
+            va="bottom",
+            fontsize=9,
+        )
+
+    ax.set_xlabel("LLM Variant")
+    ax.set_ylabel("Avg Latency (ms)")
+    ax.set_title("LLM Ablation: Average Latency by Variant")
+    ax.set_xticks(x)
+    ax.set_xticklabels(variants, rotation=30, ha="right")
+    fig.tight_layout()
+    fig.savefig(output, dpi=100)
+    plt.close(fig)
+
+
+def save_metrics_csv(
+    all_metrics: list[VariantMetrics],
+    output: Path,
+) -> None:
+    """Write aggregated metrics to a CSV file.
+
+    Parameters
+    ----------
+    all_metrics:
+        List of variant metrics.
+    output:
+        Path to write the CSV file.
+    """
+    output.parent.mkdir(parents=True, exist_ok=True)
+    rows = [
+        {
+            "variant": m.variant,
+            "memory_turns": m.memory_turns,
+            "prompt_style": m.prompt_style,
+            "games": m.games,
+            "win_rate": round(m.win_rate, 4),
+            "avg_invalid_retries": round(m.avg_invalid_retries, 4),
+            "avg_latency_ms": round(m.avg_latency_ms, 2),
+        }
+        for m in all_metrics
+    ]
+    df = pd.DataFrame(rows)
+    df.to_csv(output, index=False)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+@click.command()
+@click.argument("csv_paths", nargs=-1, required=True)
+@click.option(
+    "--output-dir",
+    default="output",
+    show_default=True,
+    type=click.Path(),
+    help="Directory for output charts and CSV.",
+)
+@click.pass_context
+def main(ctx: click.Context, csv_paths: tuple[str, ...], output_dir: str) -> None:
+    """Generate LLM ablation charts from tournament result CSVs.
+
+    CSV_PATHS can be individual files, directories, or glob patterns.
+    """
+    try:
+        df = load_csvs(csv_paths)
+    except FileNotFoundError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        ctx.exit(1)
+        return
+
+    if df.empty:
+        click.echo("Error: no data rows found.", err=True)
+        ctx.exit(1)
+        return
+
+    # Compute overall metrics (across all opponents)
+    all_metrics = compute_metrics(df)
+
+    if not all_metrics:
+        click.echo("No LLM agent variants found in data.", err=True)
+        ctx.exit(1)
+        return
+
+    # Compute metrics grouped by opponent for the win-rate chart
+    metrics_by_opp = compute_metrics_by_opponent(df)
+
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    # Generate charts
+    plot_winrate_chart(metrics_by_opp, out / "llm_ablation_winrate.png")
+    click.echo(f"  ✓ {out / 'llm_ablation_winrate.png'}")
+
+    plot_invalid_rate_chart(all_metrics, out / "llm_ablation_invalid_rate.png")
+    click.echo(f"  ✓ {out / 'llm_ablation_invalid_rate.png'}")
+
+    plot_latency_chart(all_metrics, out / "llm_ablation_latency.png")
+    click.echo(f"  ✓ {out / 'llm_ablation_latency.png'}")
+
+    # Save metrics CSV
+    save_metrics_csv(all_metrics, out / "llm_ablation_metrics.csv")
+    click.echo(f"  ✓ {out / 'llm_ablation_metrics.csv'}")
+
+    click.echo(f"\nDone — {len(all_metrics)} variant(s) analysed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_tournament.py
+++ b/scripts/run_tournament.py
@@ -59,8 +59,36 @@ def _get_game(game_name: str):
         sys.exit(1)
 
 
-def _build_agents(game, mcts_sims: int, llm_models: tuple) -> list:
-    """Build the roster of agents for the tournament."""
+def _build_agents(
+    game,
+    mcts_sims: int,
+    llm_models: tuple,
+    reasoning_effort: str | None = None,
+    memory_turns: int = 1,
+    prompt_style: str = "board_summary_then_choice",
+) -> list:
+    """Build the roster of agents for the tournament.
+
+    Parameters
+    ----------
+    game:
+        The game wrapper instance.
+    mcts_sims:
+        Number of MCTS simulations per move.
+    llm_models:
+        Tuple of LLM model identifiers.
+    reasoning_effort:
+        Optional reasoning effort for supported models.
+    memory_turns:
+        Number of recent turns to include in LLM context (0 = stateless).
+    prompt_style:
+        Prompt style string matching a PromptStyle enum value.
+
+    Returns
+    -------
+    list
+        List of agent instances.
+    """
     from agents.random_agent import RandomAgent
 
     agents = [
@@ -96,9 +124,20 @@ def _build_agents(game, mcts_sims: int, llm_models: tuple) -> list:
         try:
             from agents.llm_agent import LLMAgent, LLMAgentConfig
             from agents.prompts import PromptStyle
-            config = LLMAgentConfig(model=llm_model, prompt_style=PromptStyle.BOARD_SUMMARY_THEN_CHOICE, memory_turns=1)
+
+            ps = PromptStyle(prompt_style)
+            config = LLMAgentConfig(
+                model=llm_model,
+                prompt_style=ps,
+                memory_turns=memory_turns,
+                reasoning_effort=reasoning_effort,
+            )
             slug = llm_model.split("/")[-1]
-            agents.append(LLMAgent(config=config, name=f"llm-{slug}"))
+            effort_tag = f"-{reasoning_effort}" if reasoning_effort else ""
+            mem_tag = f"-mem{memory_turns}"
+            agents.append(
+                LLMAgent(config=config, name=f"llm-{slug}{effort_tag}{mem_tag}")
+            )
         except Exception as exc:
             console.print(f"[yellow]LLM agent unavailable: {exc}[/yellow]")
 
@@ -137,6 +176,32 @@ def _build_agents(game, mcts_sims: int, llm_models: tuple) -> list:
     help="LLM model identifier (repeatable). e.g. --llm-model openai/gpt-4o-mini --llm-model openai/gpt-5-mini",
 )
 @click.option(
+    "--reasoning-effort",
+    default=None,
+    type=click.Choice(["low", "medium", "high", "xhigh"]),
+    help="Reasoning effort for LLM agents that support it (low/medium/high).",
+)
+@click.option(
+    "--memory-turns",
+    default=1,
+    show_default=True,
+    type=int,
+    help="Number of recent turns to include in LLM context (0 = stateless).",
+)
+@click.option(
+    "--prompt-style",
+    default="board_summary_then_choice",
+    show_default=True,
+    type=click.Choice([
+        "zero_shot",
+        "legal_moves_only",
+        "board_summary_then_choice",
+        "reason_then_choice",
+        "critic_then_choice",
+    ]),
+    help="Prompt template style for LLM agents.",
+)
+@click.option(
     "--log-level",
     default=None,
     help="Logging verbosity (default: $ARENA_LOG_LEVEL or INFO).",
@@ -152,6 +217,9 @@ def main(
     results_dir: str | None,
     mcts_sims: int,
     llm_model: tuple,
+    reasoning_effort: str | None,
+    memory_turns: int,
+    prompt_style: str,
     log_level: str | None,
     run_id: str | None,
 ) -> None:
@@ -168,7 +236,9 @@ def main(
     # ------------------------------------------------------------------
     # Build agent roster
     # ------------------------------------------------------------------
-    agents = _build_agents(game_obj, mcts_sims, llm_model)
+    agents = _build_agents(
+        game_obj, mcts_sims, llm_model, reasoning_effort, memory_turns, prompt_style
+    )
 
     console.rule("[bold blue]openspiel-arena[/bold blue]")
     console.print(f"Game              : [cyan]{game_obj.name}[/cyan]")

--- a/tests/test_llm_ablation.py
+++ b/tests/test_llm_ablation.py
@@ -1,0 +1,325 @@
+"""
+tests.test_llm_ablation — tests for scripts.plot_llm_ablation
+==============================================================
+Covers parsing, metric computation, chart generation, and CLI.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from scripts.plot_llm_ablation import (
+    VariantMetrics,
+    compute_metrics,
+    compute_metrics_by_opponent,
+    load_csvs,
+    parse_memory_turns,
+    parse_prompt_style,
+    plot_invalid_rate_chart,
+    plot_latency_chart,
+    plot_winrate_chart,
+    save_metrics_csv,
+    main,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def ablation_csv(tmp_path: Path) -> Path:
+    """Create a sample CSV with LLM ablation variants."""
+    csv_content = """run_id,game,agent_a,agent_b,agent_a_side,agent_b_side,winner,is_draw,num_moves,seed,invalid_move_retries,agent_a_latency_ms,agent_b_latency_ms,termination_reason
+id1,tic_tac_toe,llm-gpt-5.4-mini-mem0,random,0,1,llm-gpt-5.4-mini-mem0,False,7,,0,500,0,normal
+id2,tic_tac_toe,llm-gpt-5.4-mini-mem0,random,0,1,random,False,9,,1,800,0,normal
+id3,tic_tac_toe,llm-gpt-5.4-mini-mem0,mcts-50,0,1,mcts-50,False,8,,0,600,50,normal
+id4,tic_tac_toe,llm-gpt-5.4-mini-mem1,random,0,1,llm-gpt-5.4-mini-mem1,False,6,,0,450,0,normal
+id5,tic_tac_toe,llm-gpt-5.4-mini-mem1,random,0,1,llm-gpt-5.4-mini-mem1,False,7,,0,470,0,normal
+id6,tic_tac_toe,llm-gpt-5.4-mini-mem1,mcts-50,0,1,mcts-50,False,8,,1,520,55,normal
+id7,tic_tac_toe,llm-gpt-5.4-mini-mem3,random,0,1,llm-gpt-5.4-mini-mem3,False,5,,0,430,0,normal
+id8,tic_tac_toe,llm-gpt-5.4-mini-mem3,random,0,1,,True,9,,2,900,0,normal
+id9,tic_tac_toe,llm-gpt-5.4-mini-mem3,mcts-50,0,1,mcts-50,False,7,,0,480,60,normal
+id10,tic_tac_toe,random,mcts-50,0,1,mcts-50,False,10,,0,0,50,normal
+"""
+    csv_file = tmp_path / "results_ablation.csv"
+    csv_file.write_text(csv_content)
+    return csv_file
+
+
+@pytest.fixture
+def ablation_df(ablation_csv: Path) -> pd.DataFrame:
+    """Load the ablation CSV into a DataFrame."""
+    return pd.read_csv(ablation_csv)
+
+
+@pytest.fixture
+def sample_metrics() -> list[VariantMetrics]:
+    """Create sample VariantMetrics for plotting tests."""
+    return [
+        VariantMetrics("llm-gpt-5.4-mini-mem0", 0, "board_summary_then_choice", 4, 0.25, 0.25, 633.33),
+        VariantMetrics("llm-gpt-5.4-mini-mem1", 1, "board_summary_then_choice", 4, 0.625, 0.25, 480.0),
+        VariantMetrics("llm-gpt-5.4-mini-mem3", 3, "board_summary_then_choice", 4, 0.375, 0.67, 603.33),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Test parsing helpers
+# ---------------------------------------------------------------------------
+
+
+class TestParseMemoryTurns:
+    """Tests for parse_memory_turns."""
+
+    def test_mem0(self) -> None:
+        assert parse_memory_turns("llm-gpt-5.4-mini-mem0") == 0
+
+    def test_mem1(self) -> None:
+        assert parse_memory_turns("llm-gpt-5.4-mini-mem1") == 1
+
+    def test_mem3(self) -> None:
+        assert parse_memory_turns("llm-gpt-5.4-mini-mem3") == 3
+
+    def test_no_mem_token_defaults_to_1(self) -> None:
+        assert parse_memory_turns("llm-gpt-5.4-mini") == 1
+
+    def test_mem_token_at_end(self) -> None:
+        assert parse_memory_turns("llm-gpt-5.4-mini-mem5") == 5
+
+    def test_mem_token_in_middle(self) -> None:
+        assert parse_memory_turns("llm-gpt-5.4-mini-mem3-reason") == 3
+
+
+class TestParsePromptStyle:
+    """Tests for parse_prompt_style."""
+
+    def test_unknown_defaults(self) -> None:
+        assert parse_prompt_style("llm-gpt-5.4-mini-mem0") == "board_summary_then_choice"
+
+    def test_zero_shot(self) -> None:
+        assert parse_prompt_style("llm-zero_shot-mem0") == "zero_shot"
+
+    def test_reason_then_choice(self) -> None:
+        assert parse_prompt_style("llm-reason_then_choice-mem1") == "reason_then_choice"
+
+
+# ---------------------------------------------------------------------------
+# Test metric computation
+# ---------------------------------------------------------------------------
+
+
+class TestComputeMetrics:
+    """Tests for compute_metrics function."""
+
+    def test_finds_llm_variants(self, ablation_df: pd.DataFrame) -> None:
+        metrics = compute_metrics(ablation_df)
+        variants = {m.variant for m in metrics}
+        assert "llm-gpt-5.4-mini-mem0" in variants
+        assert "llm-gpt-5.4-mini-mem1" in variants
+        assert "llm-gpt-5.4-mini-mem3" in variants
+
+    def test_game_counts(self, ablation_df: pd.DataFrame) -> None:
+        metrics = compute_metrics(ablation_df)
+        by_variant = {m.variant: m for m in metrics}
+        # mem0: rows id1, id2 (agent_a), id3 (agent_a) = 3
+        assert by_variant["llm-gpt-5.4-mini-mem0"].games == 3
+        # mem1: rows id4, id5, id6 = 3
+        assert by_variant["llm-gpt-5.4-mini-mem1"].games == 3
+        # mem3: rows id7, id8, id9 = 3
+        assert by_variant["llm-gpt-5.4-mini-mem3"].games == 3
+
+    def test_win_rate_calculation(self, ablation_df: pd.DataFrame) -> None:
+        metrics = compute_metrics(ablation_df)
+        by_variant = {m.variant: m for m in metrics}
+        # mem0: 1 win (id1) + 0 draws = 1/3 ≈ 0.333
+        assert by_variant["llm-gpt-5.4-mini-mem0"].win_rate == pytest.approx(1 / 3)
+        # mem1: 2 wins (id4, id5) = 2/3 ≈ 0.667
+        assert by_variant["llm-gpt-5.4-mini-mem1"].win_rate == pytest.approx(2 / 3)
+        # mem3: 1 win (id7) + 0.5 draw (id8) = 1.5/3 = 0.5
+        assert by_variant["llm-gpt-5.4-mini-mem3"].win_rate == pytest.approx(0.5)
+
+    def test_invalid_retries(self, ablation_df: pd.DataFrame) -> None:
+        metrics = compute_metrics(ablation_df)
+        by_variant = {m.variant: m for m in metrics}
+        # mem0: retries [0, 1, 0] → avg ≈ 0.333
+        assert by_variant["llm-gpt-5.4-mini-mem0"].avg_invalid_retries == pytest.approx(1 / 3)
+
+    def test_latency(self, ablation_df: pd.DataFrame) -> None:
+        metrics = compute_metrics(ablation_df)
+        by_variant = {m.variant: m for m in metrics}
+        # mem1: latencies [450, 470, 520] → avg = 480
+        assert by_variant["llm-gpt-5.4-mini-mem1"].avg_latency_ms == pytest.approx(480.0)
+
+    def test_excludes_non_llm(self, ablation_df: pd.DataFrame) -> None:
+        metrics = compute_metrics(ablation_df)
+        variants = {m.variant for m in metrics}
+        assert "random" not in variants
+        assert "mcts-50" not in variants
+
+
+class TestComputeMetricsByOpponent:
+    """Tests for compute_metrics_by_opponent."""
+
+    def test_groups_by_opponent(self, ablation_df: pd.DataFrame) -> None:
+        result = compute_metrics_by_opponent(ablation_df)
+        assert "random" in result
+        assert "mcts-50" in result
+
+    def test_random_opponent_metrics(self, ablation_df: pd.DataFrame) -> None:
+        result = compute_metrics_by_opponent(ablation_df)
+        # Against random: mem0=2 games, mem1=2 games, mem3=2 games
+        random_metrics = {m.variant: m for m in result["random"]}
+        assert "llm-gpt-5.4-mini-mem0" in random_metrics
+        assert random_metrics["llm-gpt-5.4-mini-mem0"].games == 2
+
+
+# ---------------------------------------------------------------------------
+# Test CSV loading
+# ---------------------------------------------------------------------------
+
+
+class TestLoadCSVs:
+    """Tests for load_csvs."""
+
+    def test_load_single_file(self, ablation_csv: Path) -> None:
+        df = load_csvs([ablation_csv])
+        assert len(df) == 10
+
+    def test_load_directory(self, tmp_path: Path) -> None:
+        csv_content = """run_id,game,agent_a,agent_b,agent_a_side,agent_b_side,winner,is_draw,num_moves,seed,invalid_move_retries,agent_a_latency_ms,agent_b_latency_ms,termination_reason
+id1,tic_tac_toe,a,b,0,1,a,False,5,,0,0,0,normal
+"""
+        (tmp_path / "results_test.csv").write_text(csv_content)
+        df = load_csvs([tmp_path])
+        assert len(df) == 1
+
+    def test_nonexistent_file_raises(self) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_csvs(["/nonexistent/path.csv"])
+
+
+# ---------------------------------------------------------------------------
+# Test plotting
+# ---------------------------------------------------------------------------
+
+
+class TestPlotting:
+    """Tests for plot generation (files are created)."""
+
+    def test_plot_winrate_chart(self, tmp_path: Path, sample_metrics: list[VariantMetrics]) -> None:
+        metrics_by_opp = {"random": sample_metrics, "mcts-50": sample_metrics}
+        output = tmp_path / "winrate.png"
+        plot_winrate_chart(metrics_by_opp, output)
+        assert output.exists()
+        assert output.stat().st_size > 0
+
+    def test_plot_invalid_rate_chart(self, tmp_path: Path, sample_metrics: list[VariantMetrics]) -> None:
+        output = tmp_path / "invalid.png"
+        plot_invalid_rate_chart(sample_metrics, output)
+        assert output.exists()
+        assert output.stat().st_size > 0
+
+    def test_plot_latency_chart(self, tmp_path: Path, sample_metrics: list[VariantMetrics]) -> None:
+        output = tmp_path / "latency.png"
+        plot_latency_chart(sample_metrics, output)
+        assert output.exists()
+        assert output.stat().st_size > 0
+
+    def test_plot_empty_metrics(self, tmp_path: Path) -> None:
+        output = tmp_path / "empty.png"
+        plot_invalid_rate_chart([], output)
+        assert output.exists()
+
+
+# ---------------------------------------------------------------------------
+# Test CSV export
+# ---------------------------------------------------------------------------
+
+
+class TestSaveMetricsCSV:
+    """Tests for save_metrics_csv."""
+
+    def test_csv_format(self, tmp_path: Path, sample_metrics: list[VariantMetrics]) -> None:
+        output = tmp_path / "metrics.csv"
+        save_metrics_csv(sample_metrics, output)
+        assert output.exists()
+        df = pd.read_csv(output)
+        assert len(df) == 3
+        assert list(df.columns) == [
+            "variant", "memory_turns", "prompt_style", "games",
+            "win_rate", "avg_invalid_retries", "avg_latency_ms",
+        ]
+
+    def test_csv_values(self, tmp_path: Path, sample_metrics: list[VariantMetrics]) -> None:
+        output = tmp_path / "metrics.csv"
+        save_metrics_csv(sample_metrics, output)
+        df = pd.read_csv(output)
+        row0 = df.iloc[0]
+        assert row0["variant"] == "llm-gpt-5.4-mini-mem0"
+        assert row0["memory_turns"] == 0
+        assert row0["games"] == 4
+
+    def test_creates_parent_dirs(self, tmp_path: Path, sample_metrics: list[VariantMetrics]) -> None:
+        output = tmp_path / "nested" / "dir" / "metrics.csv"
+        save_metrics_csv(sample_metrics, output)
+        assert output.exists()
+
+
+# ---------------------------------------------------------------------------
+# Test CLI
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    """Tests for the CLI entry-point."""
+
+    def test_main_basic(self, ablation_csv: Path, tmp_path: Path) -> None:
+        from click.testing import CliRunner
+
+        output_dir = tmp_path / "output"
+        runner = CliRunner()
+        result = runner.invoke(main, [str(ablation_csv), "--output-dir", str(output_dir)])
+        assert result.exit_code == 0
+        assert (output_dir / "llm_ablation_winrate.png").exists()
+        assert (output_dir / "llm_ablation_invalid_rate.png").exists()
+        assert (output_dir / "llm_ablation_latency.png").exists()
+        assert (output_dir / "llm_ablation_metrics.csv").exists()
+
+    def test_main_no_llm_agents(self, tmp_path: Path) -> None:
+        from click.testing import CliRunner
+
+        csv_content = """run_id,game,agent_a,agent_b,agent_a_side,agent_b_side,winner,is_draw,num_moves,seed,invalid_move_retries,agent_a_latency_ms,agent_b_latency_ms,termination_reason
+id1,tic_tac_toe,random,mcts-50,0,1,random,False,5,,0,0,50,normal
+"""
+        csv_file = tmp_path / "no_llm.csv"
+        csv_file.write_text(csv_content)
+        output_dir = tmp_path / "output"
+        runner = CliRunner()
+        result = runner.invoke(main, [str(csv_file), "--output-dir", str(output_dir)])
+        assert result.exit_code == 1
+
+    def test_main_nonexistent_file(self, tmp_path: Path) -> None:
+        from click.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["/nonexistent/file.csv", "--output-dir", str(tmp_path / "out")])
+        assert result.exit_code == 1
+
+    def test_main_directory_input(self, ablation_csv: Path, tmp_path: Path) -> None:
+        """Should accept a directory containing results CSVs."""
+        from click.testing import CliRunner
+        import shutil
+
+        # Copy the csv into a subdirectory
+        results_dir = tmp_path / "results"
+        results_dir.mkdir()
+        shutil.copy(ablation_csv, results_dir / "results_ablation.csv")
+        output_dir = tmp_path / "output"
+        runner = CliRunner()
+        result = runner.invoke(main, [str(results_dir), "--output-dir", str(output_dir)])
+        assert result.exit_code == 0


### PR DESCRIPTION
Implements GitHub issue #11: ablation charts showing how memory_turns and prompt_style affect LLM agent performance.

## Changes
- `scripts/plot_llm_ablation.py` — CLI script reading results CSVs, producing 3 PNGs and metrics CSV
- `output/llm_ablation_winrate.png` — grouped bar chart by variant and opponent
- `output/llm_ablation_invalid_rate.png` — invalid move retries by variant
- `output/llm_ablation_latency.png` — avg latency by variant
- `output/llm_ablation_metrics.csv` — full metrics table
- `analysis/llm_ablation.ipynb` — Jupyter notebook walkthrough
- `tests/test_llm_ablation.py` — 31 tests, all passing

Also extends `scripts/run_tournament.py` with `--memory-turns` and `--prompt-style` CLI flags, and runs ablation tournaments on tic_tac_toe with memory_turns=0,1,3 to generate data.

Closes #11