### PR TITLE
feat: render sample game transcripts (#12)

### DIFF
--- a/agents/base.py
+++ b/agents/base.py
@@ -93,6 +93,9 @@ class BaseAgent(ABC):
 
     def __init__(self, name: str) -> None:
         self.name = name
+        # Optional: most recent LLM prompt/response (set after each select_action call)
+        self.last_prompt: str | None = None
+        self.last_response: str | None = None
 
     @abstractmethod
     def select_action(
@@ -138,6 +141,14 @@ class BaseAgent(ABC):
         """
         legal_actions = list(state.legal_actions())
         return self.select_action(state, legal_actions, context=None)
+
+    def reset(self) -> None:
+        """Reset agent state for a new game.
+
+        Subclasses may override to clear per-game caches (e.g. turn history).
+        """
+        self.last_prompt = None
+        self.last_response = None
 
     def __repr__(self) -> str:  # pragma: no cover
         return f"{self.__class__.__name__}(name={self.name!r})"

--- a/agents/llm_agent.py
+++ b/agents/llm_agent.py
@@ -228,6 +228,7 @@ class LLMAgent(BaseAgent):
 
     def reset(self) -> None:
         """Reset the agent state for a new game."""
+        super().reset()
         self._turn_history = []
         self._game_history = []
 
@@ -297,6 +298,10 @@ class LLMAgent(BaseAgent):
                 f"LLM returned invalid action. Raw response: {raw_response[:200]!r}. "
                 f"Using fallback: {chosen_action}"
             )
+
+        # Expose prompt/response for transcript capture
+        self.last_prompt = prompt
+        self.last_response = raw_response
 
         # Record turn
         record = TurnRecord(

--- a/analysis/transcript_examples.ipynb
+++ b/analysis/transcript_examples.ipynb
@@ -1,0 +1,178 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Transcript Examples — Loading and Rendering Game Transcripts\n",
+    "\n",
+    "This notebook demonstrates how to load saved game transcripts and render\n",
+    "board snapshots and HTML reports."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from scripts.render_transcripts import (\n",
+    "    load_transcripts,\n",
+    "    render_board_png,\n",
+    "    render_tic_tac_toe_board,\n",
+    "    render_transcript_html,\n",
+    "    select_bad_game,\n",
+    "    select_good_game,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Load all transcripts from a directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transcripts_dir = \"transcripts/\"\n",
+    "transcripts = load_transcripts(transcripts_dir)\n",
+    "print(f\"Loaded {len(transcripts)} transcripts\")\n",
+    "\n",
+    "# Show a summary table\n",
+    "for t in transcripts[:5]:\n",
+    "    print(f\"  {t['match_id'][:8]}…: {t['agent_a']:>25} vs {t['agent_b']:<25} winner={t['winner']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Auto-select good and bad games"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "good = select_good_game(transcripts)\n",
+    "bad = select_bad_game(transcripts)\n",
+    "\n",
+    "print(f\"Good game: {good['match_id']}\")\n",
+    "print(f\"  {good['agent_a']} vs {good['agent_b']} → winner={good['winner']}, moves={good['num_moves']}\")\n",
+    "print()\n",
+    "print(f\"Bad game:  {bad['match_id']}\")\n",
+    "print(f\"  {bad['agent_a']} vs {bad['agent_b']} → winner={bad['winner']}, retries={bad['invalid_move_retries']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Inspect individual moves"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Show moves from the good game\n",
+    "for entry in good['entries']:\n",
+    "    llm_tag = \"\"\n",
+    "    if entry.get('llm_prompt'):\n",
+    "        llm_tag = \" (LLM)\"\n",
+    "    print(f\"  Move {entry['move_num']}: Player {entry['player']} ({entry['agent_name']}{llm_tag}) → action {entry['action']}\")\n",
+    "    print(f\"    Board:\\n{entry['board_str']}\")\n",
+    "    print()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Render board snapshots"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Render the good game's final board to PNG\n",
+    "render_board_png(good, \"output/notebook_good_game.png\")\n",
+    "print(\"Saved: output/notebook_good_game.png\")\n",
+    "\n",
+    "# Display inline\n",
+    "from IPython.display import Image, display\n",
+    "display(Image(filename=\"output/notebook_good_game.png\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Generate HTML reports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate HTML for both games\n",
+    "render_transcript_html(good, \"output/notebook_good_game.html\", label=\"Good Game\")\n",
+    "render_transcript_html(bad, \"output/notebook_bad_game.html\", label=\"Bad Game\")\n",
+    "print(\"Saved: output/notebook_good_game.html\")\n",
+    "print(\"Saved: output/notebook_bad_game.html\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Load and inspect a specific transcript by match_id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pick any transcript by ID\n",
+    "match_id = transcripts[0]['match_id']\n",
+    "t = json.loads(Path(f\"transcripts/{match_id}.json\").read_text())\n",
+    "print(json.dumps({k: v for k, v in t.items() if k != 'entries'}, indent=2))\n",
+    "print(f\"\\nMoves played: {len(t['entries'])}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/arena/match.py
+++ b/arena/match.py
@@ -6,11 +6,20 @@ Runs one game between two agents on an OpenSpiel game and returns a
 
 The function is intentionally side-effect-free (no file I/O); callers are
 responsible for persisting the returned result.
+
+Transcript saving
+-----------------
+When *save_transcript_dir* is provided, a per-move transcript JSON is written
+to ``{save_transcript_dir}/{match_id}.json`` after the game completes.  Each
+entry captures the board state, legal actions, agent name, chosen action,
+and (for LLM agents) the prompt and response text.
 """
 
 from __future__ import annotations
 
+import json
 import time
+from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from arena.result import MatchResult
@@ -31,6 +40,7 @@ def run_match(
     *,
     seed: int | None = None,
     max_invalid_retries: int = DEFAULT_MAX_INVALID_RETRIES,
+    save_transcript_dir: str | None = None,
 ) -> MatchResult:
     """Run a single game and return the outcome.
 
@@ -47,6 +57,8 @@ def run_match(
     max_invalid_retries:
         Maximum number of retries per turn when an agent returns an
         invalid action (default: 3).
+    save_transcript_dir:
+        If provided, save a per-move transcript JSON to this directory.
 
     Returns
     -------
@@ -54,6 +66,12 @@ def run_match(
         Full record of the completed match, including latency metrics,
         invalid move retries, and termination reason.
     """
+    # Reset agent state for a new game (clears last_prompt/last_response etc.)
+    if hasattr(agent_a, "reset"):
+        agent_a.reset()
+    if hasattr(agent_b, "reset"):
+        agent_b.reset()
+
     state = game.new_state()
     moves: list[int] = []
 
@@ -63,14 +81,25 @@ def run_match(
     agent_b_total_latency_ms = 0.0
     termination_reason: Literal["normal", "invalid_move_limit"] = "normal"
 
+    # Transcript capture
+    transcript_entries: list[dict] = []
+    move_num = 0
+
     while not game.is_terminal(state):
         current_player = game.current_player(state)
         agent = agent_a if current_player == 0 else agent_b
         legal_actions = game.legal_actions(state)
 
+        # Clear per-move prompt/response so we can read them after select_action
+        if hasattr(agent, "last_prompt"):
+            agent.last_prompt = None
+        if hasattr(agent, "last_response"):
+            agent.last_response = None
+
         # Track per-move latency
         retries_this_turn = 0
         action: int | None = None
+        was_invalid_retry = False
 
         while retries_this_turn <= max_invalid_retries:
             start_time = time.perf_counter()
@@ -94,16 +123,32 @@ def run_match(
                 break
 
             # Invalid move - retry
+            was_invalid_retry = True
             retries_this_turn += 1
             total_invalid_retries += 1
 
             # If we've exceeded retries, terminate the game
             if retries_this_turn > max_invalid_retries:
                 termination_reason = "invalid_move_limit"
+
+                # Record transcript entry for the failed move
+                if save_transcript_dir is not None:
+                    board_str = _safe_observation_string(game, state)
+                    transcript_entries.append({
+                        "move_num": move_num,
+                        "player": current_player,
+                        "agent_name": agent.name,
+                        "action": None,
+                        "board_str": board_str,
+                        "legal_actions": legal_actions,
+                        "llm_prompt": getattr(agent, "last_prompt", None),
+                        "llm_response": getattr(agent, "last_response", None),
+                        "was_invalid_retry": True,
+                    })
+
                 # Forfeit: the current player loses
-                # Create a result with the opponent as winner
                 winner = agent_b.name if current_player == 0 else agent_a.name
-                return MatchResult(
+                result = MatchResult(
                     agent_a=agent_a.name,
                     agent_b=agent_b.name,
                     game_name=game.name,
@@ -120,10 +165,35 @@ def run_match(
                     termination_reason=termination_reason,
                 )
 
+                # Save transcript
+                if save_transcript_dir is not None:
+                    _save_transcript(
+                        save_transcript_dir, result.match_id,
+                        transcript_entries, result,
+                    )
+
+                return result
+
         # Apply the valid action
         if action is not None:
+            # Record transcript entry before applying
+            if save_transcript_dir is not None:
+                board_str = _safe_observation_string(game, state)
+                transcript_entries.append({
+                    "move_num": move_num,
+                    "player": current_player,
+                    "agent_name": agent.name,
+                    "action": action,
+                    "board_str": board_str,
+                    "legal_actions": legal_actions,
+                    "llm_prompt": getattr(agent, "last_prompt", None),
+                    "llm_response": getattr(agent, "last_response", None),
+                    "was_invalid_retry": was_invalid_retry,
+                })
+
             game.apply_action(state, action)
             moves.append(action)
+            move_num += 1
 
     # Game completed normally
     returns = game.returns(state)
@@ -134,7 +204,7 @@ def run_match(
     else:
         winner = None
 
-    return MatchResult(
+    result = MatchResult(
         agent_a=agent_a.name,
         agent_b=agent_b.name,
         game_name=game.name,
@@ -150,3 +220,64 @@ def run_match(
         agent_b_latency_ms=agent_b_total_latency_ms,
         termination_reason=termination_reason,
     )
+
+    # Save transcript
+    if save_transcript_dir is not None:
+        _save_transcript(
+            save_transcript_dir, result.match_id,
+            transcript_entries, result,
+        )
+
+    return result
+
+
+def _safe_observation_string(game: "GameWrapper", state: object) -> str:
+    """Try to get observation_string; fall back to str(state)."""
+    if hasattr(state, "observation_string"):
+        try:
+            return state.observation_string(player_id=0)  # type: ignore[call-arg]
+        except Exception:
+            pass
+    if hasattr(game, "state_string"):
+        return game.state_string(state)
+    return str(state)
+
+
+def _save_transcript(
+    transcript_dir: str,
+    match_id: str,
+    entries: list[dict],
+    result: MatchResult,
+) -> None:
+    """Persist a transcript JSON to disk.
+
+    Parameters
+    ----------
+    transcript_dir:
+        Target directory (created if it does not exist).
+    match_id:
+        Unique match identifier used as the filename stem.
+    entries:
+        Per-move transcript dictionaries.
+    result:
+        The final ``MatchResult`` for this game.
+    """
+    out_path = Path(transcript_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    payload = {
+        "match_id": match_id,
+        "game_name": result.game_name,
+        "agent_a": result.agent_a,
+        "agent_b": result.agent_b,
+        "winner": result.winner,
+        "num_moves": result.num_moves,
+        "returns": result.returns,
+        "termination_reason": result.termination_reason,
+        "invalid_move_retries": result.invalid_move_retries,
+        "moves": result.moves,
+        "entries": entries,
+    }
+
+    with open(out_path / f"{match_id}.json", "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, ensure_ascii=False)

--- a/arena/tournament.py
+++ b/arena/tournament.py
@@ -136,6 +136,7 @@ def run_tournament(
     *,
     results_dir: str | Path | None = None,
     run_id: str | None = None,
+    transcripts_dir: str | Path | None = None,
 ) -> tuple[TournamentResult, TournamentManifest]:
     """Run a full round-robin tournament with side swaps.
 
@@ -157,6 +158,8 @@ def run_tournament(
         If None, results are not persisted to disk (manifest still tracks them).
     run_id:
         Unique identifier for this run. Auto-generated if omitted.
+    transcripts_dir:
+        If provided, per-move transcript JSONs are written to this directory.
 
     Returns
     -------
@@ -208,7 +211,8 @@ def run_tournament(
             logger.debug(f"Match {match_num}/{total_matches}: {agent_a.name} vs {agent_b.name}")
 
             try:
-                result = run_match(agent_a, agent_b, game)
+                save_td = str(transcripts_dir) if transcripts_dir else None
+                result = run_match(agent_a, agent_b, game, save_transcript_dir=save_td)
                 tournament_result.matches.append(result)
 
                 # Write to CSV immediately so data isn't lost on crash

--- a/scripts/render_transcripts.py
+++ b/scripts/render_transcripts.py
@@ -1,0 +1,547 @@
+#!/usr/bin/env python3
+"""
+scripts.render_transcripts — turn saved transcript JSONs into HTML + PNG artefacts
+====================================================================================
+Selects a "good" and a "bad" game from a transcripts directory, then produces
+slide-ready HTML move-by-move transcripts and matplotlib board snapshots.
+
+Usage::
+
+    python scripts/render_transcripts.py --transcripts-dir transcripts/ --output-dir output/
+    python scripts/render_transcripts.py --good-game <MATCH_ID> --bad-game <MATCH_ID>
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import click
+import matplotlib
+
+matplotlib.use("Agg")  # non-interactive backend for headless rendering
+import matplotlib.pyplot as plt  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Transcript loading
+# ---------------------------------------------------------------------------
+
+
+def load_transcripts(transcripts_dir: str | Path) -> list[dict]:
+    """Load all transcript JSON files from *transcripts_dir*.
+
+    Parameters
+    ----------
+    transcripts_dir:
+        Directory containing ``{match_id}.json`` files.
+
+    Returns
+    -------
+    list[dict]
+        Parsed transcript payloads sorted by filename for determinism.
+    """
+    tdir = Path(transcripts_dir)
+    if not tdir.is_dir():
+        raise FileNotFoundError(f"Transcripts directory not found: {tdir}")
+
+    transcripts: list[dict] = []
+    for fp in sorted(tdir.glob("*.json")):
+        with open(fp, encoding="utf-8") as f:
+            transcripts.append(json.load(f))
+    return transcripts
+
+
+def load_transcript(path: str | Path) -> dict:
+    """Load a single transcript JSON file."""
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+# ---------------------------------------------------------------------------
+# Game selection logic
+# ---------------------------------------------------------------------------
+
+
+def _is_llm_match(t: dict) -> bool:
+    """Return True if either agent is an LLM agent (name contains 'llm')."""
+    return "llm" in t.get("agent_a", "").lower() or "llm" in t.get("agent_b", "").lower()
+
+
+def _llm_won(t: dict) -> bool:
+    """Return True if the LLM agent won this match."""
+    if not _is_llm_match(t):
+        return False
+    winner = t.get("winner")
+    if not winner:
+        return False
+    return "llm" in winner.lower()
+
+
+def select_good_game(transcripts: list[dict]) -> dict | None:
+    """Select the best game where the LLM performed well.
+
+    Criteria (in priority order):
+    1. LLM agent won
+    2. Low ``invalid_move_retries``
+    3. Reasonable number of moves (5–15)
+
+    Falls back to non-LLM games with clean play if no LLM win is found.
+    """
+    # Prefer LLM wins
+    llm_wins = [t for t in transcripts if _llm_won(t)]
+    if llm_wins:
+        return sorted(llm_wins, key=lambda t: (t["invalid_move_retries"], t["num_moves"]))[0]
+
+    # Fallback: any game with 0 retries and reasonable length
+    candidates = [
+        t for t in transcripts
+        if t.get("invalid_move_retries", 0) == 0
+        and 5 <= t.get("num_moves", 0) <= 15
+    ]
+    if candidates:
+        return candidates[len(candidates) // 2]  # pick a middle one
+
+    # Last resort: just pick the first transcript
+    return transcripts[0] if transcripts else None
+
+
+def select_bad_game(transcripts: list[dict]) -> dict | None:
+    """Select a game where the LLM performed poorly.
+
+    Criteria:
+    1. LLM agent lost OR high ``invalid_move_retries``
+    2. Highest retries first
+    """
+    # Prefer LLM losses with retries
+    llm_losses = [t for t in transcripts if _is_llm_match(t) and not _llm_won(t)]
+    if llm_losses:
+        return sorted(llm_losses, key=lambda t: -t.get("invalid_move_retries", 0))[0]
+
+    # Fallback: highest retries
+    if transcripts:
+        return sorted(transcripts, key=lambda t: -t.get("invalid_move_retries", 0))[0]
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Board rendering (matplotlib)
+# ---------------------------------------------------------------------------
+
+
+def render_tic_tac_toe_board(
+    transcript: dict,
+    output_path: str | Path,
+    move_index: int | None = None,
+    figsize: tuple[float, float] = (19.2, 10.8),
+    dpi: int = 100,
+) -> Path:
+    """Render a tic-tac-toe board snapshot as a PNG.
+
+    Parameters
+    ----------
+    transcript:
+        Loaded transcript dict with ``entries`` and ``moves``.
+    output_path:
+        Destination file path for the PNG.
+    move_index:
+        Which move to render (None = final state).
+    figsize:
+        Figure size in inches (default 1920×1080 @ 100 DPI).
+    dpi:
+        Resolution.
+
+    Returns
+    -------
+    Path
+        The path the image was written to.
+    """
+    entries = transcript.get("entries", [])
+    if not entries:
+        # Render an empty board
+        board = [""] * 9
+    else:
+        # Replay up to move_index (or all moves)
+        idx = move_index if move_index is not None else len(entries) - 1
+        idx = min(idx, len(entries) - 1)
+
+        # Parse the board from the last entry's board_str
+        # We replay the moves to construct the board state
+        board = _replay_tic_tac_toe(entries, idx)
+
+    fig, ax = plt.subplots(1, 1, figsize=figsize, dpi=dpi)
+    ax.set_xlim(-0.5, 2.5)
+    ax.set_ylim(-0.5, 2.5)
+    ax.set_aspect("equal")
+    ax.axis("off")
+
+    # Title
+    agent_a = transcript.get("agent_a", "Player 0")
+    agent_b = transcript.get("agent_b", "Player 1")
+    winner = transcript.get("winner")
+    title = f"{agent_a} (X) vs {agent_b} (O)"
+    if winner:
+        title += f"  —  Winner: {winner}"
+    elif transcript.get("num_moves", 0) >= 9:
+        title += "  —  Draw"
+    ax.set_title(title, fontsize=28, fontweight="bold", pad=20)
+
+    # Grid lines
+    for i in range(1, 3):
+        ax.axhline(y=i - 0.5, color="black", linewidth=3)
+        ax.axvline(x=i - 0.5, color="black", linewidth=3)
+
+    # Pieces
+    symbols = {0: "X", 1: "O"}
+    colors = {0: "#2196F3", 1: "#F44336"}  # blue / red
+
+    for pos, piece in enumerate(board):
+        if piece == "":
+            continue
+        row, col = divmod(pos, 3)
+        player_id = int(piece)
+        ax.text(
+            col, 2 - row,
+            symbols.get(player_id, "?"),
+            ha="center", va="center",
+            fontsize=80, fontweight="bold",
+            color=colors.get(player_id, "black"),
+        )
+
+    # Position labels
+    for pos in range(9):
+        row, col = divmod(pos, 3)
+        if board[pos] == "":
+            ax.text(
+                col, 2 - row,
+                str(pos),
+                ha="center", va="center",
+                fontsize=24, color="#CCCCCC",
+            )
+
+    plt.tight_layout()
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out, bbox_inches="tight", dpi=dpi)
+    plt.close(fig)
+    return out
+
+
+def _replay_tic_tac_toe(entries: list[dict], up_to: int) -> list[str]:
+    """Replay tic-tac-toe moves to reconstruct the board at index *up_to*.
+
+    Returns a list of 9 strings: "" for empty, "0" for X (player 0), "1" for O (player 1).
+    """
+    board = [""] * 9
+    for i in range(up_to + 1):
+        entry = entries[i]
+        action = entry.get("action")
+        if action is None:
+            continue
+        player = entry.get("player", i % 2)
+        if 0 <= action < 9:
+            board[action] = str(player)
+    return board
+
+
+def render_board_png(
+    transcript: dict,
+    output_path: str | Path,
+    move_index: int | None = None,
+) -> Path:
+    """Auto-detect game type and render the board PNG.
+
+    Currently supports ``tic_tac_toe``.
+    """
+    game_name = transcript.get("game_name", "")
+    if game_name == "tic_tac_toe":
+        return render_tic_tac_toe_board(transcript, output_path, move_index)
+    else:
+        # Generic fallback: render a text-based info card
+        return _render_generic_card(transcript, output_path)
+
+
+def _render_generic_card(transcript: dict, output_path: str | Path) -> Path:
+    """Render a generic info card for unsupported games."""
+    fig, ax = plt.subplots(figsize=(19.2, 10.8), dpi=100)
+    ax.axis("off")
+    lines = [
+        f"Game: {transcript.get('game_name', '?')}",
+        f"{transcript.get('agent_a', '?')} vs {transcript.get('agent_b', '?')}",
+        f"Winner: {transcript.get('winner', 'Draw')}",
+        f"Moves: {transcript.get('num_moves', 0)}",
+    ]
+    ax.text(0.5, 0.5, "\n".join(lines), ha="center", va="center",
+            fontsize=36, fontfamily="monospace", transform=ax.transAxes)
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out, bbox_inches="tight", dpi=100)
+    plt.close(fig)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# HTML rendering
+# ---------------------------------------------------------------------------
+
+
+def render_transcript_html(transcript: dict, output_path: str | Path, label: str = "") -> Path:
+    """Render a move-by-move transcript as a standalone HTML file.
+
+    The HTML uses inline styles so it looks good without an external stylesheet.
+
+    Parameters
+    ----------
+    transcript:
+        Loaded transcript dict.
+    output_path:
+        Destination HTML file path.
+    label:
+        Optional label like "Good Game" or "Bad Game" for the heading.
+
+    Returns
+    -------
+    Path
+        Path the HTML was written to.
+    """
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    entries = transcript.get("entries", [])
+    winner = transcript.get("winner", "Draw")
+    game_name = transcript.get("game_name", "unknown")
+    agent_a = transcript.get("agent_a", "?")
+    agent_b = transcript.get("agent_b", "?")
+    num_moves = transcript.get("num_moves", 0)
+    retries = transcript.get("invalid_move_retries", 0)
+    termination = transcript.get("termination_reason", "normal")
+
+    # Build HTML
+    heading = f" ({label})" if label else ""
+    rows_html = ""
+    for entry in entries:
+        move_num = entry.get("move_num", "?")
+        player = entry.get("player", "?")
+        agent_name = entry.get("agent_name", "?")
+        action = entry.get("action", "N/A")
+        board_str = entry.get("board_str", "")
+        legal_actions = entry.get("legal_actions", [])
+        llm_prompt = entry.get("llm_prompt")
+        llm_response = entry.get("llm_response")
+        was_invalid = entry.get("was_invalid_retry", False)
+
+        invalid_badge = ""
+        if was_invalid:
+            invalid_badge = (
+                '<span style="background:#F44336;color:white;padding:2px 8px;'
+                'border-radius:4px;font-size:12px;margin-left:8px;">'
+                "INVALID RETRY</span>"
+            )
+
+        prompt_section = ""
+        if llm_prompt:
+            prompt_section = (
+                '<div style="margin-top:8px;">'
+                '<span style="font-weight:bold;color:#1565C0;">LLM Prompt:</span>'
+                f'<pre style="background:#F5F5F5;padding:8px;border-radius:4px;'
+                f'font-size:13px;overflow-x:auto;white-space:pre-wrap;">'
+                f"{escape_html(llm_prompt)}</pre></div>"
+            )
+
+        response_section = ""
+        if llm_response:
+            response_section = (
+                '<div style="margin-top:4px;">'
+                '<span style="font-weight:bold;color:#C62828;">LLM Response:</span>'
+                f'<pre style="background:#FFF3E0;padding:8px;border-radius:4px;'
+                f'font-size:13px;overflow-x:auto;white-space:pre-wrap;">'
+                f"{escape_html(llm_response)}</pre></div>"
+            )
+
+        board_html = ""
+        if board_str:
+            board_html = (
+                '<pre style="font-size:16px;letter-spacing:4px;'
+                'background:#E8F5E9;padding:8px;border-radius:4px;'
+                'display:inline-block;">'
+                f"{escape_html(board_str)}</pre>"
+            )
+
+        rows_html += f"""
+        <tr style="border-bottom:1px solid #E0E0E0;">
+            <td style="padding:8px;text-align:center;font-weight:bold;">{move_num}</td>
+            <td style="padding:8px;text-align:center;">Player {player}</td>
+            <td style="padding:8px;">{escape_html(agent_name)}</td>
+            <td style="padding:8px;text-align:center;font-weight:bold;">{action}{invalid_badge}</td>
+            <td style="padding:8px;">{board_html}</td>
+            <td style="padding:8px;font-size:12px;">{legal_actions}</td>
+            <td style="padding:8px;">
+                {prompt_section}
+                {response_section}
+            </td>
+        </tr>"""
+
+    html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Game Transcript: {game_name} — {agent_a} vs {agent_b}{heading}</title>
+</head>
+<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+             max-width:1400px;margin:0 auto;padding:24px;background:#FAFAFA;color:#212121;">
+
+<h1 style="text-align:center;color:#1565C0;">
+    Game Transcript{heading}: {escape_html(game_name)}
+</h1>
+<p style="text-align:center;font-size:18px;">
+    <strong>{escape_html(agent_a)}</strong> (Player 0)
+    vs
+    <strong>{escape_html(agent_b)}</strong> (Player 1)
+</p>
+
+<table style="width:100%;margin:16px auto;border-collapse:collapse;background:white;
+              border-radius:8px;overflow:hidden;box-shadow:0 2px 8px rgba(0,0,0,0.1);">
+<tr style="background:#1565C0;color:white;">
+    <th style="padding:10px;">Move</th>
+    <th style="padding:10px;">Player</th>
+    <th style="padding:10px;">Agent</th>
+    <th style="padding:10px;">Action</th>
+    <th style="padding:10px;">Board</th>
+    <th style="padding:10px;">Legal Actions</th>
+    <th style="padding:10px;">LLM Details</th>
+</tr>
+{rows_html}
+</table>
+
+<div style="margin-top:24px;padding:16px;background:white;border-radius:8px;
+            box-shadow:0 2px 8px rgba(0,0,0,0.1);">
+<h2 style="color:#1565C0;">Game Summary</h2>
+<table style="width:100%;font-size:16px;">
+<tr><td style="padding:4px 8px;font-weight:bold;">Winner:</td>
+    <td style="padding:4px 8px;">{escape_html(str(winner))}</td></tr>
+<tr><td style="padding:4px 8px;font-weight:bold;">Total Moves:</td>
+    <td style="padding:4px 8px;">{num_moves}</td></tr>
+<tr><td style="padding:4px 8px;font-weight:bold;">Invalid Move Retries:</td>
+    <td style="padding:4px 8px;">{retries}</td></tr>
+<tr><td style="padding:4px 8px;font-weight:bold;">Termination:</td>
+    <td style="padding:4px 8px;">{escape_html(termination)}</td></tr>
+<tr><td style="padding:4px 8px;font-weight:bold;">Returns:</td>
+    <td style="padding:4px 8px;">{transcript.get('returns', [])}</td></tr>
+</table>
+</div>
+
+</body>
+</html>"""
+
+    with open(out, "w", encoding="utf-8") as f:
+        f.write(html)
+    return out
+
+
+def escape_html(text: str) -> str:
+    """Escape HTML special characters."""
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+@click.command()
+@click.option(
+    "--transcripts-dir",
+    default="transcripts/",
+    show_default=True,
+    help="Directory containing transcript JSON files.",
+)
+@click.option(
+    "--output-dir",
+    default="output/",
+    show_default=True,
+    help="Directory for output HTML and PNG files.",
+)
+@click.option(
+    "--good-game",
+    default=None,
+    help="Specific match_id for the good game (auto-selected if omitted).",
+)
+@click.option(
+    "--bad-game",
+    default=None,
+    help="Specific match_id for the bad game (auto-selected if omitted).",
+)
+def main(
+    transcripts_dir: str,
+    output_dir: str,
+    good_game: str | None,
+    bad_game: str | None,
+) -> None:
+    """Render HTML + PNG transcripts from saved game transcripts."""
+    transcripts = load_transcripts(transcripts_dir)
+    if not transcripts:
+        click.echo("No transcripts found.", err=True)
+        sys.exit(1)
+
+    click.echo(f"Loaded {len(transcripts)} transcripts from {transcripts_dir}")
+
+    # Resolve good game
+    if good_game:
+        good_t = _find_by_match_id(transcripts, good_game)
+        if not good_t:
+            click.echo(f"Good game match_id not found: {good_game}", err=True)
+            sys.exit(1)
+    else:
+        good_t = select_good_game(transcripts)
+
+    # Resolve bad game
+    if bad_game:
+        bad_t = _find_by_match_id(transcripts, bad_game)
+        if not bad_t:
+            click.echo(f"Bad game match_id not found: {bad_game}", err=True)
+            sys.exit(1)
+    else:
+        bad_t = select_bad_game(transcripts)
+
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    if good_t:
+        mid = good_t["match_id"]
+        click.echo(f"Rendering good game: {mid}")
+        render_board_png(good_t, out / "example_good_llm_game.png")
+        render_transcript_html(good_t, out / "example_good_llm_game.html", label="Good Game")
+        click.echo(f"  → output/example_good_llm_game.png")
+        click.echo(f"  → output/example_good_llm_game.html")
+
+    if bad_t:
+        mid = bad_t["match_id"]
+        click.echo(f"Rendering bad game: {mid}")
+        render_board_png(bad_t, out / "example_bad_llm_game.png")
+        render_transcript_html(bad_t, out / "example_bad_llm_game.html", label="Bad Game")
+        click.echo(f"  → output/example_bad_llm_game.png")
+        click.echo(f"  → output/example_bad_llm_game.html")
+
+    click.echo("Done.")
+
+
+def _find_by_match_id(transcripts: list[dict], match_id: str) -> dict | None:
+    """Find a transcript by its match_id."""
+    for t in transcripts:
+        if t.get("match_id") == match_id:
+            return t
+    return None
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_tournament.py
+++ b/scripts/run_tournament.py
@@ -202,6 +202,19 @@ def _build_agents(
     help="Prompt template style for LLM agents.",
 )
 @click.option(
+    "--save-transcripts",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Save per-move transcript JSONs for every match.",
+)
+@click.option(
+    "--transcripts-dir",
+    default="transcripts/",
+    show_default=True,
+    help="Directory for transcript JSON files (used with --save-transcripts).",
+)
+@click.option(
     "--log-level",
     default=None,
     help="Logging verbosity (default: $ARENA_LOG_LEVEL or INFO).",
@@ -220,6 +233,8 @@ def main(
     reasoning_effort: str | None,
     memory_turns: int,
     prompt_style: str,
+    save_transcripts: bool,
+    transcripts_dir: str,
     log_level: str | None,
     run_id: str | None,
 ) -> None:
@@ -262,6 +277,7 @@ def main(
         rounds_per_pairing=rounds_per_pairing,
         results_dir=out_dir,
         run_id=run_id,
+        transcripts_dir=transcripts_dir if save_transcripts else None,
     )
 
     # ------------------------------------------------------------------

--- a/tests/test_transcript_renderer.py
+++ b/tests/test_transcript_renderer.py
@@ -1,0 +1,317 @@
+"""
+tests.test_transcript_renderer — tests for the transcript rendering pipeline
+=============================================================================
+Covers transcript JSON format validation, game selection logic, board rendering,
+and HTML output.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# We need matplotlib for board rendering tests
+# ---------------------------------------------------------------------------
+matplotlib = pytest.importorskip("matplotlib")
+matplotlib.use("Agg")
+
+from scripts.render_transcripts import (  # noqa: E402
+    _is_llm_match,
+    _llm_won,
+    escape_html,
+    load_transcripts,
+    render_board_png,
+    render_tic_tac_toe_board,
+    render_transcript_html,
+    select_bad_game,
+    select_good_game,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def sample_transcript_good() -> dict:
+    """A 'good' transcript where an LLM agent wins cleanly."""
+    return {
+        "match_id": "good-001",
+        "game_name": "tic_tac_toe",
+        "agent_a": "llm-gpt-mini",
+        "agent_b": "random",
+        "winner": "llm-gpt-mini",
+        "num_moves": 7,
+        "returns": [1.0, -1.0],
+        "termination_reason": "normal",
+        "invalid_move_retries": 0,
+        "moves": [4, 0, 1, 5, 2, 3, 7],
+        "entries": [
+            {"move_num": 0, "player": 0, "agent_name": "llm-gpt-mini", "action": 4,
+             "board_str": "...\n...\n...", "legal_actions": [0,1,2,3,4,5,6,7,8],
+             "llm_prompt": "You are playing tic-tac-toe...", "llm_response": "I choose action 4 (center)",
+             "was_invalid_retry": False},
+            {"move_num": 1, "player": 1, "agent_name": "random", "action": 0,
+             "board_str": "O..\n...\n.X.", "legal_actions": [0,1,2,3,5,6,7,8],
+             "llm_prompt": None, "llm_response": None, "was_invalid_retry": False},
+            {"move_num": 2, "player": 0, "agent_name": "llm-gpt-mini", "action": 1,
+             "board_str": "O..\n...\n.X.", "legal_actions": [1,2,3,5,6,7,8],
+             "llm_prompt": "Board state:\nO..\n...\n.X.\nChoose action.", "llm_response": "Action 1",
+             "was_invalid_retry": False},
+        ],
+    }
+
+
+@pytest.fixture()
+def sample_transcript_bad() -> dict:
+    """A 'bad' transcript where the LLM agent lost with many retries."""
+    return {
+        "match_id": "bad-001",
+        "game_name": "tic_tac_toe",
+        "agent_a": "llm-gpt-mini",
+        "agent_b": "mcts-50",
+        "winner": "mcts-50",
+        "num_moves": 1,
+        "returns": [-1.0, 1.0],
+        "termination_reason": "invalid_move_limit",
+        "invalid_move_retries": 4,
+        "moves": [8],
+        "entries": [
+            {"move_num": 0, "player": 0, "agent_name": "llm-gpt-mini", "action": None,
+             "board_str": "...\n...\n...", "legal_actions": [0,1,2,3,4,5,6,7,8],
+             "llm_prompt": "Choose an action...", "llm_response": "Let me place at position 99",
+             "was_invalid_retry": True},
+        ],
+    }
+
+
+@pytest.fixture()
+def transcripts_dir(tmp_path: Path, sample_transcript_good: dict, sample_transcript_bad: dict) -> Path:
+    """Write sample transcripts to a temp dir."""
+    for t in [sample_transcript_good, sample_transcript_bad]:
+        (tmp_path / f"{t['match_id']}.json").write_text(json.dumps(t), encoding="utf-8")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Transcript JSON format validation
+# ---------------------------------------------------------------------------
+
+class TestTranscriptFormat:
+    """Validate the structure of transcript JSON payloads."""
+
+    REQUIRED_KEYS = [
+        "match_id", "game_name", "agent_a", "agent_b",
+        "winner", "num_moves", "entries",
+    ]
+
+    ENTRY_KEYS = [
+        "move_num", "player", "agent_name", "action",
+        "board_str", "legal_actions", "was_invalid_retry",
+    ]
+
+    def test_transcript_has_required_keys(self, sample_transcript_good: dict):
+        for key in self.REQUIRED_KEYS:
+            assert key in sample_transcript_good, f"Missing key: {key}"
+
+    def test_entries_are_list_of_dicts(self, sample_transcript_good: dict):
+        entries = sample_transcript_good["entries"]
+        assert isinstance(entries, list)
+        assert len(entries) > 0
+        for entry in entries:
+            assert isinstance(entry, dict)
+
+    def test_each_entry_has_required_keys(self, sample_transcript_good: dict):
+        for entry in sample_transcript_good["entries"]:
+            for key in self.ENTRY_KEYS:
+                assert key in entry, f"Entry missing key: {key}"
+
+    def test_moves_list_matches_num_moves(self, sample_transcript_good: dict):
+        assert len(sample_transcript_good["moves"]) == sample_transcript_good["num_moves"]
+
+    def test_llm_fields_present(self, sample_transcript_good: dict):
+        """LLM entries should have llm_prompt and llm_response keys (can be None)."""
+        for entry in sample_transcript_good["entries"]:
+            assert "llm_prompt" in entry
+            assert "llm_response" in entry
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Game selection logic
+# ---------------------------------------------------------------------------
+
+class TestGameSelection:
+    """Test good/bad game auto-selection criteria."""
+
+    def test_select_good_game_prefers_llm_win(self, sample_transcript_good: dict, sample_transcript_bad: dict):
+        transcripts = [sample_transcript_bad, sample_transcript_good]
+        result = select_good_game(transcripts)
+        assert result is not None
+        assert result["match_id"] == "good-001"
+
+    def test_select_bad_game_prefers_llm_loss(self, sample_transcript_good: dict, sample_transcript_bad: dict):
+        transcripts = [sample_transcript_good, sample_transcript_bad]
+        result = select_bad_game(transcripts)
+        assert result is not None
+        assert result["match_id"] == "bad-001"
+
+    def test_select_bad_game_sorts_by_retries(self):
+        t1 = {"match_id": "a", "agent_a": "llm", "agent_b": "x", "winner": "x",
+               "invalid_move_retries": 2, "num_moves": 5, "entries": []}
+        t2 = {"match_id": "b", "agent_a": "llm", "agent_b": "x", "winner": "x",
+               "invalid_move_retries": 10, "num_moves": 0, "entries": []}
+        result = select_bad_game([t1, t2])
+        assert result["match_id"] == "b"
+
+    def test_select_good_game_fallback_no_llm(self):
+        t = {
+            "match_id": "fallback-1", "game_name": "tic_tac_toe",
+            "agent_a": "random", "agent_b": "mcts",
+            "winner": "mcts", "num_moves": 7,
+            "invalid_move_retries": 0, "entries": [],
+        }
+        result = select_good_game([t])
+        assert result["match_id"] == "fallback-1"
+
+    def test_is_llm_match(self, sample_transcript_good: dict, sample_transcript_bad: dict):
+        assert _is_llm_match(sample_transcript_good) is True
+        non_llm = {"agent_a": "random", "agent_b": "mcts"}
+        assert _is_llm_match(non_llm) is False
+
+    def test_llm_won(self, sample_transcript_good: dict, sample_transcript_bad: dict):
+        assert _llm_won(sample_transcript_good) is True
+        assert _llm_won(sample_transcript_bad) is False
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Board rendering produces valid matplotlib figure
+# ---------------------------------------------------------------------------
+
+class TestBoardRendering:
+    """Test that board PNGs are produced correctly."""
+
+    def test_render_tic_tac_toe_produces_png(self, sample_transcript_good: dict, tmp_path: Path):
+        out = tmp_path / "board.png"
+        result = render_tic_tac_toe_board(sample_transcript_good, out)
+        assert result.exists()
+        assert result.stat().st_size > 0
+        # PNG files start with the signature bytes 0x89504e47
+        data = result.read_bytes()
+        assert data[:4] == b"\x89PNG"
+
+    def test_render_board_png_auto_detects_ttt(self, sample_transcript_good: dict, tmp_path: Path):
+        out = tmp_path / "auto_board.png"
+        result = render_board_png(sample_transcript_good, out)
+        assert result.exists()
+        assert result.stat().st_size > 0
+
+    def test_render_at_specific_move_index(self, sample_transcript_good: dict, tmp_path: Path):
+        out = tmp_path / "move0.png"
+        render_tic_tac_toe_board(sample_transcript_good, out, move_index=0)
+        assert out.exists()
+        assert out.stat().st_size > 0
+
+    def test_render_empty_board(self, tmp_path: Path):
+        """A transcript with no entries should still produce a valid PNG."""
+        t = {
+            "match_id": "empty", "game_name": "tic_tac_toe",
+            "agent_a": "a", "agent_b": "b", "winner": None,
+            "num_moves": 0, "entries": [],
+        }
+        out = tmp_path / "empty.png"
+        render_tic_tac_toe_board(t, out)
+        assert out.exists()
+        assert out.stat().st_size > 0
+
+    def test_render_generic_game(self, tmp_path: Path):
+        """Non-tic-tac-toe games should produce a generic card PNG."""
+        t = {
+            "match_id": "gen", "game_name": "breakthrough",
+            "agent_a": "a", "agent_b": "b", "winner": "a",
+            "num_moves": 10, "entries": [],
+        }
+        out = tmp_path / "generic.png"
+        result = render_board_png(t, out)
+        assert result.exists()
+
+
+# ---------------------------------------------------------------------------
+# Test 4: HTML output contains expected sections
+# ---------------------------------------------------------------------------
+
+class TestHTMLOutput:
+    """Validate the structure and content of rendered HTML."""
+
+    def test_html_contains_game_title(self, sample_transcript_good: dict, tmp_path: Path):
+        out = tmp_path / "transcript.html"
+        render_transcript_html(sample_transcript_good, out, label="Good Game")
+        html = out.read_text(encoding="utf-8")
+        assert "tic_tac_toe" in html
+        assert "Good Game" in html
+
+    def test_html_contains_agent_names(self, sample_transcript_good: dict, tmp_path: Path):
+        out = tmp_path / "transcript.html"
+        render_transcript_html(sample_transcript_good, out)
+        html = out.read_text(encoding="utf-8")
+        assert "llm-gpt-mini" in html
+        assert "random" in html
+
+    def test_html_contains_move_table(self, sample_transcript_good: dict, tmp_path: Path):
+        out = tmp_path / "transcript.html"
+        render_transcript_html(sample_transcript_good, out)
+        html = out.read_text(encoding="utf-8")
+        assert "<table" in html
+        assert "Move" in html
+        assert "Action" in html
+        assert "Agent" in html
+
+    def test_html_contains_llm_prompt_and_response(self, sample_transcript_good: dict, tmp_path: Path):
+        out = tmp_path / "transcript.html"
+        render_transcript_html(sample_transcript_good, out)
+        html = out.read_text(encoding="utf-8")
+        assert "LLM Prompt" in html
+        assert "LLM Response" in html
+        assert "tic-tac-toe" in html
+
+    def test_html_contains_summary_section(self, sample_transcript_good: dict, tmp_path: Path):
+        out = tmp_path / "transcript.html"
+        render_transcript_html(sample_transcript_good, out)
+        html = out.read_text(encoding="utf-8")
+        assert "Game Summary" in html
+        assert "Winner" in html
+
+    def test_html_uses_inline_styles(self, sample_transcript_good: dict, tmp_path: Path):
+        out = tmp_path / "transcript.html"
+        render_transcript_html(sample_transcript_good, out)
+        html = out.read_text(encoding="utf-8")
+        assert 'style="' in html  # inline styles present
+        assert '<link rel="stylesheet"' not in html  # no external stylesheets
+
+    def test_html_escapes_special_chars(self):
+        result = escape_html('<script>alert("xss")</script>')
+        assert "<script>" not in result
+        assert "&lt;script&gt;" in result
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Loading transcripts from disk
+# ---------------------------------------------------------------------------
+
+class TestLoadTranscripts:
+    """Test transcript loading from a directory."""
+
+    def test_load_from_dir(self, transcripts_dir: Path):
+        transcripts = load_transcripts(transcripts_dir)
+        assert len(transcripts) == 2
+
+    def test_load_missing_dir_raises(self):
+        with pytest.raises(FileNotFoundError):
+            load_transcripts("/nonexistent/path")
+
+    def test_load_single_transcript(self, transcripts_dir: Path):
+        from scripts.render_transcripts import load_transcript
+        t = load_transcript(transcripts_dir / "good-001.json")
+        assert t["match_id"] == "good-001"


### PR DESCRIPTION
## Summary

Implements #12 — render talk-ready game transcript examples.

### Changes

**Step 1: Transcript saving pipeline**
- `arena/match.py`: Added `save_transcript_dir` parameter to `run_match()`. When set, saves a per-move transcript JSON capturing move number, player, agent name, action, board state, legal actions, LLM prompt/response, and invalid retry status.
- `agents/base.py`: Added `last_prompt` / `last_response` attributes and `reset()` method to `BaseAgent`.
- `agents/llm_agent.py`: Exposes prompt/response after each `select_action()` call.
- `arena/tournament.py`: Passes `transcripts_dir` through to `run_match()`.
- `scripts/run_tournament.py`: Added `--save-transcripts` flag and `--transcripts-dir` option.

**Step 2: Tournament run**
- Ran 24-match tic_tac_toe tournament with transcripts saved to `transcripts/`.

**Step 3: Renderer**
- `scripts/render_transcripts.py`: CLI tool that auto-selects good/bad games and produces:
  - **PNG board snapshots** (1920×1080) via matplotlib
  - **HTML move-by-move transcripts** with inline styles, LLM prompt/response sections, and game summary
- `analysis/transcript_examples.ipynb`: Notebook showing how to load and render transcripts
- `tests/test_transcript_renderer.py`: 26 tests covering format validation, game selection, board rendering, and HTML output

### Output files
- `output/example_good_llm_game.png` — board snapshot of a clean game
- `output/example_good_llm_game.html` — full move-by-move transcript
- `output/example_bad_llm_game.png` — board snapshot of a game with LLM failures
- `output/example_bad_llm_game.html` — full move-by-move transcript

### Test results
```
26 passed in tests/test_transcript_renderer.py
All existing tests pass (no regressions)
```